### PR TITLE
fix: harden offline support, bound recovery loops, improve build & media session

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -57,7 +57,7 @@ async function minifyJS() {
             if (file.endsWith(".js")) {
                 const inputFile = path.join(jsSrcFolder, file);
                 const outputFile = path.join(jsDistFolder, file);
-                await execPromise(`npx terser ${inputFile} -o ${outputFile} --compress 'drop_console=true' --mangle --toplevel --output ${outputFile}`);
+                await execPromise(`npx terser ${inputFile} -o ${outputFile} --compress 'pure_funcs=["console.log","console.info","console.debug"]' --mangle --toplevel --output ${outputFile}`);
                 console.log(`✅ Minified & Obfuscated (Strong): ${file}`);
             }
         }

--- a/build.mjs
+++ b/build.mjs
@@ -57,7 +57,7 @@ async function minifyJS() {
             if (file.endsWith(".js")) {
                 const inputFile = path.join(jsSrcFolder, file);
                 const outputFile = path.join(jsDistFolder, file);
-                await execPromise(`npx terser ${inputFile} -o ${outputFile} --compress 'pure_funcs=["console.log","console.info","console.debug"]' --mangle --toplevel`);
+                await execPromise(`npx terser "${inputFile}" -o "${outputFile}" --compress 'pure_funcs=["console.log","console.info","console.debug"]' --mangle --toplevel`);
                 console.log(`✅ Minified & Obfuscated (Strong): ${file}`);
             }
         }

--- a/build.mjs
+++ b/build.mjs
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 import path from "path";
 import { fileURLToPath } from "url";
 import { minify } from "html-minifier-terser";
+import { minify as terserMinify } from "terser";
 import { exec } from "child_process";
 import { promisify } from "util";
 
@@ -57,7 +58,13 @@ async function minifyJS() {
             if (file.endsWith(".js")) {
                 const inputFile = path.join(jsSrcFolder, file);
                 const outputFile = path.join(jsDistFolder, file);
-                await execPromise(`npx terser "${inputFile}" -o "${outputFile}" --compress 'pure_funcs=["console.log","console.info","console.debug"]' --mangle --toplevel`);
+                const code = await fs.readFile(inputFile, 'utf8');
+                const result = await terserMinify(code, {
+                    compress: { pure_funcs: ['console.log', 'console.info', 'console.debug'] },
+                    mangle: true,
+                    toplevel: true,
+                });
+                await fs.writeFile(outputFile, result.code);
                 console.log(`✅ Minified & Obfuscated (Strong): ${file}`);
             }
         }

--- a/build.mjs
+++ b/build.mjs
@@ -64,6 +64,9 @@ async function minifyJS() {
                     mangle: true,
                     toplevel: true,
                 });
+                if (!result || !result.code) {
+                    throw new Error(`Terser returned empty output for ${file}`);
+                }
                 await fs.writeFile(outputFile, result.code);
                 console.log(`✅ Minified & Obfuscated (Strong): ${file}`);
             }

--- a/build.mjs
+++ b/build.mjs
@@ -57,7 +57,7 @@ async function minifyJS() {
             if (file.endsWith(".js")) {
                 const inputFile = path.join(jsSrcFolder, file);
                 const outputFile = path.join(jsDistFolder, file);
-                await execPromise(`npx terser ${inputFile} -o ${outputFile} --compress 'pure_funcs=["console.log","console.info","console.debug"]' --mangle --toplevel --output ${outputFile}`);
+                await execPromise(`npx terser ${inputFile} -o ${outputFile} --compress 'pure_funcs=["console.log","console.info","console.debug"]' --mangle --toplevel`);
                 console.log(`✅ Minified & Obfuscated (Strong): ${file}`);
             }
         }

--- a/e2e/radio.spec.js
+++ b/e2e/radio.spec.js
@@ -372,8 +372,17 @@ test.describe('Offline — cached resources', () => {
 
     await page.goto('/');
 
-    // Wait for SW to install and pre-cache sounds + images to be fetched
-    await page.waitForTimeout(3000);
+    // Wait for SW to activate and pre-cache sounds
+    await page.waitForFunction(() =>
+      navigator.serviceWorker.ready.then(reg => reg.active !== null),
+      { timeout: 10000 }
+    );
+    // Give SW time to finish cache.addAll in install event
+    await page.waitForFunction(async () => {
+      const cache = await caches.open('radio-sounds-v1');
+      const keys = await cache.keys();
+      return keys.length >= 2;
+    }, { timeout: 10000 });
 
     // Go offline WITHOUT ever pressing play
     await page.context().setOffline(true);

--- a/e2e/radio.spec.js
+++ b/e2e/radio.spec.js
@@ -365,4 +365,44 @@ test.describe('Offline — cached resources', () => {
     expect(paused).toBe(false);
     expect(src).toMatch(/^blob:/);
   });
+
+  test('sounds and error image work offline without prior play (SW pre-cache)', async ({ page }) => {
+    await page.route(/res\.cloudinary\.com/, (route) =>
+      route.fulfill({ status: 200, contentType: 'image/png', body: PIXEL_PNG }));
+
+    await page.goto('/');
+
+    // Wait for SW to install and pre-cache sounds + images to be fetched
+    await page.waitForTimeout(3000);
+
+    // Go offline WITHOUT ever pressing play
+    await page.context().setOffline(true);
+
+    // Click next — should trigger error state with sound + image from cache
+    await page.locator('#nextButton').click();
+    await expect(page.locator('#errorMsg')).not.toHaveClass(/invisible/, { timeout: 3000 });
+
+    // Error image should render offline
+    await page.waitForFunction(() => {
+      const img = document.querySelector('#posterImage img');
+      return img.complete && img.naturalWidth > 0;
+    }, { timeout: 5000 });
+
+    // Error sound should play (from SW cache or blob)
+    await page.waitForTimeout(500);
+    const errorPlaying = await page.evaluate(() => {
+      const el = document.getElementById('errorNoise');
+      return !el.paused;
+    });
+    expect(errorPlaying).toBe(true);
+
+    // Stop — should show idle image offline
+    await page.locator('#stopButton').click();
+    await expect(page.locator('#playButton')).toBeVisible();
+
+    await page.waitForFunction(() => {
+      const img = document.querySelector('#posterImage img');
+      return img.complete && img.naturalWidth > 0;
+    }, { timeout: 5000 });
+  });
 });

--- a/src/js/radioCore.js
+++ b/src/js/radioCore.js
@@ -10,6 +10,7 @@ import { createStateMachine } from './stateMachine.js';
 export const MAX_RETRIES = 1;
 export const LOADING_TIMEOUT_MS = 6000;
 export const RECOVERY_DELAY_MS = 10000;
+export const MAX_RECOVERY_ATTEMPTS = 30;
 
 const STATE_FX = {
   idle:       { button: 'play',  loading: 'stop',  error: 'stop',  loadingMsg: false, errorMsg: false },
@@ -47,6 +48,7 @@ export function createRadioCore(deps) {
 
   const timers = { retry: null, loading: null, recovery: null };
   let retryCount = 0;
+  let recoveryCount = 0;
   let currentPlayId = 0;
   let lastPauseTime = null;
 
@@ -71,6 +73,7 @@ export function createRadioCore(deps) {
     _clearTimeout(timers.recovery);
     currentPlayId++;
     retryCount = 0;
+    recoveryCount = 0;
     lastPauseTime = null;
     setState('idle');
     playerPause();
@@ -83,7 +86,10 @@ export function createRadioCore(deps) {
     _clearTimeout(timers.retry);
     _clearTimeout(timers.loading);
     _clearTimeout(timers.recovery);
-    if (!_isRetry) retryCount = 0;
+    if (!_isRetry) {
+      retryCount = 0;
+      recoveryCount = 0;
+    }
 
     // No point trying if offline — go straight to error and auto-recover later
     if (!isOnline()) {
@@ -212,6 +218,7 @@ export function createRadioCore(deps) {
 
   // Schedule a silent recovery attempt after RECOVERY_DELAY_MS
   function scheduleRecovery() {
+    if (recoveryCount >= MAX_RECOVERY_ATTEMPTS) return;
     _clearTimeout(timers.recovery);
     timers.recovery = _setTimeout(() => {
       retryFromError();
@@ -232,6 +239,7 @@ export function createRadioCore(deps) {
 
     _clearTimeout(timers.loading);
     _clearTimeout(timers.recovery);
+    recoveryCount++;
 
     const index = getSelectedIndex();
     const playId = ++currentPlayId;
@@ -255,6 +263,7 @@ export function createRadioCore(deps) {
       if (playId !== currentPlayId) return;
       _clearTimeout(timers.loading);
       retryCount = 0;
+      recoveryCount = 0;
       saveLastIndex(index);
       setState('playing');
     }).catch((error) => {
@@ -292,6 +301,7 @@ export function createRadioCore(deps) {
     onPlayButtonClick,
     _getPlayId: () => currentPlayId,
     _getRetryCount: () => retryCount,
+    _getRecoveryCount: () => recoveryCount,
     _getTimers: () => timers,
   };
 }

--- a/src/js/radioCore.js
+++ b/src/js/radioCore.js
@@ -219,6 +219,7 @@ export function createRadioCore(deps) {
   // Schedule a silent recovery attempt after RECOVERY_DELAY_MS
   function scheduleRecovery() {
     if (recoveryCount >= MAX_RECOVERY_ATTEMPTS) return;
+    recoveryCount++;
     _clearTimeout(timers.recovery);
     timers.recovery = _setTimeout(() => {
       retryFromError();
@@ -239,7 +240,6 @@ export function createRadioCore(deps) {
 
     _clearTimeout(timers.loading);
     _clearTimeout(timers.recovery);
-    recoveryCount++;
 
     const index = getSelectedIndex();
     const playId = ++currentPlayId;

--- a/src/js/radioCore.test.js
+++ b/src/js/radioCore.test.js
@@ -735,7 +735,8 @@ describe('max recovery attempts', () => {
     await flushPromises();
     fireTimer(deps, RECOVERY_DELAY_MS);
     await flushPromises();
-    expect(core._getRecoveryCount()).toBe(2);
+    // count=3: initial scheduleRecovery(1) + two failed retryFromError re-schedules(2,3)
+    expect(core._getRecoveryCount()).toBe(3);
 
     // Now make recovery succeed
     deps._setPlayerPlayResult(Promise.resolve());
@@ -798,5 +799,33 @@ describe('max recovery attempts', () => {
 
     expect(core.getState()).toBe('playing');
     expect(core._getRecoveryCount()).toBe(0);
+  });
+
+  it('offline recovery loops are also bounded by MAX_RECOVERY_ATTEMPTS', async () => {
+    let online = true;
+    const { deps } = makeDeps({ isOnline: () => online });
+    deps._setPlayerPlayResult(Promise.reject(new Error('fail')));
+    const core = createRadioCore(deps);
+
+    // Get to error state (online)
+    core.playRadio(0);
+    await flushPromises();
+    fireTimer(deps, 3000);
+    await flushPromises();
+    expect(core.getState()).toBe('error');
+
+    // Go offline and exhaust all recovery attempts
+    online = false;
+    for (let i = 0; i < MAX_RECOVERY_ATTEMPTS; i++) {
+      fireTimer(deps, RECOVERY_DELAY_MS);
+      await flushPromises();
+    }
+
+    expect(core.getState()).toBe('error');
+    expect(core._getRecoveryCount()).toBe(MAX_RECOVERY_ATTEMPTS);
+
+    // No more recovery timers — loop is capped even while offline
+    const hasRecoveryTimer = [...deps._pendingTimers.values()].some(t => t.ms === RECOVERY_DELAY_MS);
+    expect(hasRecoveryTimer).toBe(false);
   });
 });

--- a/src/js/radioCore.test.js
+++ b/src/js/radioCore.test.js
@@ -655,7 +655,7 @@ describe('restart after long pause', () => {
 
 describe('max recovery attempts', () => {
   it('stops scheduling recovery after MAX_RECOVERY_ATTEMPTS', async () => {
-    const { deps, calls } = makeDeps();
+    const { deps } = makeDeps();
     deps._setPlayerPlayResult(Promise.reject(new Error('fail')));
     const core = createRadioCore(deps);
 
@@ -681,7 +681,7 @@ describe('max recovery attempts', () => {
   });
 
   it('resets recovery count on successful playRadio', async () => {
-    const { deps, calls } = makeDeps();
+    const { deps } = makeDeps();
     deps._setPlayerPlayResult(Promise.reject(new Error('fail')));
     const core = createRadioCore(deps);
 
@@ -702,7 +702,7 @@ describe('max recovery attempts', () => {
   });
 
   it('resets recovery count on stopRadio', async () => {
-    const { deps, calls } = makeDeps();
+    const { deps } = makeDeps();
     deps._setPlayerPlayResult(Promise.reject(new Error('fail')));
     const core = createRadioCore(deps);
 

--- a/src/js/radioCore.test.js
+++ b/src/js/radioCore.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createRadioCore, MAX_RETRIES } from './radioCore.js';
+import { createRadioCore, MAX_RECOVERY_ATTEMPTS, RECOVERY_DELAY_MS } from './radioCore.js';
 
 // --- Helpers ---
 
@@ -646,5 +646,157 @@ describe('restart after long pause', () => {
     core.onPlayerPlay();
 
     expect(core.getState()).toBe('playing'); // normal resume
+  });
+});
+
+// =============================================
+// MAX RECOVERY ATTEMPTS
+// =============================================
+
+describe('max recovery attempts', () => {
+  it('stops scheduling recovery after MAX_RECOVERY_ATTEMPTS', async () => {
+    const { deps, calls } = makeDeps();
+    deps._setPlayerPlayResult(Promise.reject(new Error('fail')));
+    const core = createRadioCore(deps);
+
+    // Get to error state
+    core.playRadio(0);
+    await flushPromises();
+    fireTimer(deps, 3000); // retry
+    await flushPromises(); // → error
+    expect(core.getState()).toBe('error');
+
+    // Exhaust all recovery attempts
+    for (let i = 0; i < MAX_RECOVERY_ATTEMPTS; i++) {
+      fireTimer(deps, RECOVERY_DELAY_MS); // scheduleRecovery fires retryFromError
+      await flushPromises(); // recovery .catch → error + scheduleRecovery
+    }
+
+    expect(core.getState()).toBe('error');
+    expect(core._getRecoveryCount()).toBe(MAX_RECOVERY_ATTEMPTS);
+
+    // No more timers should be pending for recovery
+    const hasRecoveryTimer = [...deps._pendingTimers.values()].some(t => t.ms === RECOVERY_DELAY_MS);
+    expect(hasRecoveryTimer).toBe(false);
+  });
+
+  it('resets recovery count on successful playRadio', async () => {
+    const { deps, calls } = makeDeps();
+    deps._setPlayerPlayResult(Promise.reject(new Error('fail')));
+    const core = createRadioCore(deps);
+
+    // Get to error with some recovery attempts
+    core.playRadio(0);
+    await flushPromises();
+    fireTimer(deps, 3000);
+    await flushPromises();
+    fireTimer(deps, RECOVERY_DELAY_MS);
+    await flushPromises();
+    expect(core._getRecoveryCount()).toBeGreaterThan(0);
+
+    // Now play succeeds — should reset recovery count
+    deps._setPlayerPlayResult(Promise.resolve());
+    core.playRadio(0);
+    await flushPromises();
+    expect(core._getRecoveryCount()).toBe(0);
+  });
+
+  it('resets recovery count on stopRadio', async () => {
+    const { deps, calls } = makeDeps();
+    deps._setPlayerPlayResult(Promise.reject(new Error('fail')));
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    await flushPromises();
+    fireTimer(deps, 3000);
+    await flushPromises();
+    fireTimer(deps, RECOVERY_DELAY_MS);
+    await flushPromises();
+    expect(core._getRecoveryCount()).toBeGreaterThan(0);
+
+    core.stopRadio();
+    expect(core._getRecoveryCount()).toBe(0);
+  });
+
+  it('resets recovery count when silent recovery succeeds', async () => {
+    const { deps } = makeDeps();
+    deps._setPlayerPlayResult(Promise.reject(new Error('fail')));
+    const core = createRadioCore(deps);
+
+    // Get to error state
+    core.playRadio(0);
+    await flushPromises();
+    fireTimer(deps, 3000);
+    await flushPromises();
+    expect(core.getState()).toBe('error');
+
+    // Do a few failed recoveries
+    fireTimer(deps, RECOVERY_DELAY_MS);
+    await flushPromises();
+    fireTimer(deps, RECOVERY_DELAY_MS);
+    await flushPromises();
+    expect(core._getRecoveryCount()).toBe(2);
+
+    // Now make recovery succeed
+    deps._setPlayerPlayResult(Promise.resolve());
+    fireTimer(deps, RECOVERY_DELAY_MS);
+    await flushPromises();
+
+    expect(core.getState()).toBe('playing');
+    expect(core._getRecoveryCount()).toBe(0);
+  });
+
+  it('offline recovery reschedules without attempting stream', async () => {
+    let online = true;
+    const { deps, calls } = makeDeps({ isOnline: () => online });
+    deps._setPlayerPlayResult(Promise.reject(new Error('fail')));
+    const core = createRadioCore(deps);
+
+    // Get to error state
+    core.playRadio(0);
+    await flushPromises();
+    fireTimer(deps, 3000);
+    await flushPromises();
+    expect(core.getState()).toBe('error');
+
+    // Go offline
+    online = false;
+    const playsBefore = calls.playerPlay.length;
+
+    // Fire recovery while offline — should reschedule, not attempt stream
+    fireTimer(deps, RECOVERY_DELAY_MS);
+    await flushPromises();
+
+    expect(core.getState()).toBe('error');
+    // No playerPlay attempted while offline
+    expect(calls.playerPlay.length).toBe(playsBefore);
+    // A new recovery timer was scheduled
+    const hasRecoveryTimer = [...deps._pendingTimers.values()].some(t => t.ms === RECOVERY_DELAY_MS);
+    expect(hasRecoveryTimer).toBe(true);
+  });
+
+  it('onPlayButtonClick from recovering resets recovery count', async () => {
+    const { deps } = makeDeps();
+    deps._setPlayerPlayResult(Promise.reject(new Error('fail')));
+    const core = createRadioCore(deps);
+
+    // Get to error → recovering
+    core.playRadio(0);
+    await flushPromises();
+    fireTimer(deps, 3000);
+    await flushPromises();
+    expect(core.getState()).toBe('error');
+
+    fireTimer(deps, RECOVERY_DELAY_MS);
+    await flushPromises();
+    expect(core._getRecoveryCount()).toBeGreaterThan(0);
+
+    // User presses play manually — should reset and start fresh
+    deps._setPlayerPlayResult(Promise.resolve());
+    core.onPlayButtonClick();
+    await flushPromises();
+
+    expect(core.getState()).toBe('playing');
+    expect(core._getRecoveryCount()).toBe(0);
   });
 });

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -75,13 +75,17 @@ function audioInstance(htmlElement) {
   let isPlaying = false;
   let blobUrl = null;
   let playGeneration = 0;
+  let preloadPromise = null;
 
   const preloadBlob = () => {
-    if (blobUrl) return;
-    fetch(initialSrc)
+    if (blobUrl || preloadPromise) return;
+    preloadPromise = fetch(initialSrc)
       .then(r => r.blob())
       .then(blob => { blobUrl = URL.createObjectURL(blob); })
-      .catch(err => console.warn('Audio blob preload failed:', initialSrc, err));
+      .catch(err => {
+        preloadPromise = null;
+        console.warn('Audio blob preload failed:', initialSrc, err);
+      });
   };
 
   return {

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -38,8 +38,11 @@ function cloudinaryImageUrl(text, live = false) {
   return `https://res.cloudinary.com/adrianf/image/upload/c_scale,h_480,w_480/w_400,g_south_west,x_50,y_70,c_fit,l_text:arial_90:${text}/${live ? url_live : url_non_live}`;
 }
 
-// Pre-cache status images into Cache API so they're reliably available offline
-const STATUS_IMAGE_TEXTS = Object.values(LABELS);
+// Pre-cache status images + station name images into Cache API for offline use
+const STATUS_IMAGE_TEXTS = [
+  ...Object.values(LABELS),
+  ...Array.from(radioSelect.options).map(o => o.text),
+];
 if ('caches' in window) {
   caches.open('radio-images-v2').then(cache => {
     STATUS_IMAGE_TEXTS.forEach(text => {

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -142,7 +142,16 @@ if (hasRestoredStation) {
 function registerMediaSessionHandlers() {
   navigator.mediaSession.setActionHandler('previoustrack', () => core.prevRadio());
   navigator.mediaSession.setActionHandler('nexttrack',     () => core.nextRadio());
-  navigator.mediaSession.setActionHandler('pause',         () => core.pauseRadio());
+  navigator.mediaSession.setActionHandler('pause', () => {
+    const s = core.getState();
+    // During loading/error the sound effects are playing, not the stream.
+    // "Pause" should cancel everything (same as the on-screen stop button).
+    if (s === 'loading' || s === 'retrying' || s === 'error' || s === 'recovering') {
+      core.stopRadio();
+    } else {
+      core.pauseRadio();
+    }
+  });
   navigator.mediaSession.setActionHandler('play',          () => core.resumeRadio());
   navigator.mediaSession.setActionHandler('seekbackward', null);
   navigator.mediaSession.setActionHandler('seekforward',  null);
@@ -164,6 +173,18 @@ loadingNoise.addEventListener('play', reRegisterMediaSessionHandlers);
 loadingNoise.addEventListener('playing', reRegisterMediaSessionHandlers);
 errorNoise.addEventListener('play', reRegisterMediaSessionHandlers);
 errorNoise.addEventListener('playing', reRegisterMediaSessionHandlers);
+
+// Mobile browsers re-read duration from the active <audio> element after our
+// initial setPositionState() clear, causing a countdown timer to appear.
+// Repeatedly clear it on every timeupdate tick so the OS never shows the
+// sound effect's finite duration.
+function clearSfxPositionState() {
+  if ('mediaSession' in navigator) {
+    try { navigator.mediaSession.setPositionState(); } catch (_) {}
+  }
+}
+loadingNoise.addEventListener('timeupdate', clearSfxPositionState);
+errorNoise.addEventListener('timeupdate', clearSfxPositionState);
 
 // When a sound effect pauses (e.g. loadingSound.stop() after stream loaded),
 // macOS briefly shows "Not Playing" because the active audio source just stopped.

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -168,7 +168,7 @@ function reRegisterMediaSessionHandlers() {
   navigator.mediaSession.playbackState = 'playing';
   registerMediaSessionHandlers();
   // iOS picks up the sound effect's duration as "now playing" — clear it.
-  try { navigator.mediaSession.setPositionState(); } catch (_) {}
+  try { navigator.mediaSession.setPositionState({}); } catch (_) {}
 }
 loadingNoise.addEventListener('play', reRegisterMediaSessionHandlers);
 loadingNoise.addEventListener('playing', reRegisterMediaSessionHandlers);
@@ -199,7 +199,7 @@ function reassertPlaybackState() {
   const s = core.getState();
   if (s === 'playing' || s === 'loading' || s === 'retrying' || s === 'error' || s === 'recovering') {
     navigator.mediaSession.playbackState = 'playing';
-    try { navigator.mediaSession.setPositionState(); } catch (_) {}
+    try { navigator.mediaSession.setPositionState({}); } catch (_) {}
   }
 }
 loadingNoise.addEventListener('pause', reassertPlaybackState);
@@ -254,7 +254,7 @@ const updateMediaSession = (newState) => {
     // Clear position state for active/paused states — tells the OS there's no
     // seekable timeline, so it won't show a finite progress bar.
     if (isLive || isLoading || hasError || newState === 'paused') {
-      try { navigator.mediaSession.setPositionState(); } catch (_) {}
+      try { navigator.mediaSession.setPositionState({}); } catch (_) {}
     }
   }
 

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -181,10 +181,10 @@ errorNoise.addEventListener('playing', reRegisterMediaSessionHandlers);
 // sound effect's finite duration.
 // Feature-detect once to avoid repeated exceptions on unsupported browsers.
 let canClearPositionState = true;
-try { navigator.mediaSession.setPositionState(); } catch (_) { canClearPositionState = false; }
+try { navigator.mediaSession.setPositionState({}); } catch (_) { canClearPositionState = false; }
 function clearSfxPositionState() {
   if (canClearPositionState) {
-    try { navigator.mediaSession.setPositionState(); } catch (_) { canClearPositionState = false; }
+    try { navigator.mediaSession.setPositionState({}); } catch (_) { canClearPositionState = false; }
   }
 }
 loadingNoise.addEventListener('timeupdate', clearSfxPositionState);

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -126,6 +126,13 @@ function audioInstance(htmlElement) {
 const loadingNoiseInstance = audioInstance(loadingNoise);
 const errorNoiseInstance = audioInstance(errorNoise);
 
+// Eagerly preload sound blobs for returning users so they're available offline.
+// fetch() doesn't need a user gesture — only playback does.
+if (hasRestoredStation) {
+  loadingNoiseInstance.preloadBlob();
+  errorNoiseInstance.preloadBlob();
+}
+
 // Shared helper — registers all MediaSession action handlers.
 // Called from both updateMediaSession() (every state transition) and
 // reRegisterMediaSessionHandlers() (after sound-effect playback steals focus).
@@ -328,8 +335,18 @@ player.addEventListener('stalled', () => {
 window.addEventListener('online', () => core.retryFromError());
 
 // Prev / Next
-prevButton.addEventListener('click', () => core.prevRadio());
-nextButton.addEventListener('click', () => core.nextRadio());
+prevButton.addEventListener('click', () => {
+  preloadAudioBlobs();
+  loadingNoiseInstance.warmUp();
+  errorNoiseInstance.warmUp();
+  core.prevRadio();
+});
+nextButton.addEventListener('click', () => {
+  preloadAudioBlobs();
+  loadingNoiseInstance.warmUp();
+  errorNoiseInstance.warmUp();
+  core.nextRadio();
+});
 
 // Keep alive worker
 const worker = new Worker("./js/keepAlive.js");

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -41,7 +41,7 @@ function cloudinaryImageUrl(text, live = false) {
 // Pre-cache status images into Cache API so they're reliably available offline
 const STATUS_IMAGE_TEXTS = Object.values(LABELS);
 if ('caches' in window) {
-  caches.open('radio-images').then(cache => {
+  caches.open('radio-images-v2').then(cache => {
     STATUS_IMAGE_TEXTS.forEach(text => {
       const url = cloudinaryImageUrl(text);
       cache.match(url)

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -84,7 +84,7 @@ function audioInstance(htmlElement) {
   const preloadBlob = () => {
     if (blobUrl || preloadPromise) return;
     preloadPromise = fetch(initialSrc)
-      .then(r => r.blob())
+      .then(r => { if (!r.ok) throw new Error(r.status); return r.blob(); })
       .then(blob => { blobUrl = URL.createObjectURL(blob); })
       .catch(err => {
         preloadPromise = null;

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -35,7 +35,8 @@ const LABELS = {
 function cloudinaryImageUrl(text, live = false) {
   const url_non_live = 'nndti4oybhdzggf8epvh';
   const url_live = 'rhz6yy4btbqicjqhsy7a';
-  return `https://res.cloudinary.com/adrianf/image/upload/c_scale,h_480,w_480/w_400,g_south_west,x_50,y_70,c_fit,l_text:arial_90:${text}/${live ? url_live : url_non_live}`;
+  const encoded = encodeURIComponent(text);
+  return `https://res.cloudinary.com/adrianf/image/upload/c_scale,h_480,w_480/w_400,g_south_west,x_50,y_70,c_fit,l_text:arial_90:${encoded}/${live ? url_live : url_non_live}`;
 }
 
 // Pre-cache status images + station name images into Cache API for offline use
@@ -178,9 +179,12 @@ errorNoise.addEventListener('playing', reRegisterMediaSessionHandlers);
 // initial setPositionState() clear, causing a countdown timer to appear.
 // Repeatedly clear it on every timeupdate tick so the OS never shows the
 // sound effect's finite duration.
+// Feature-detect once to avoid repeated exceptions on unsupported browsers.
+let canClearPositionState = true;
+try { navigator.mediaSession.setPositionState(); } catch (_) { canClearPositionState = false; }
 function clearSfxPositionState() {
-  if ('mediaSession' in navigator) {
-    try { navigator.mediaSession.setPositionState(); } catch (_) {}
+  if (canClearPositionState) {
+    try { navigator.mediaSession.setPositionState(); } catch (_) { canClearPositionState = false; }
   }
 }
 loadingNoise.addEventListener('timeupdate', clearSfxPositionState);

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,11 +1,25 @@
-// Service Worker — kept minimal
-// Audio sounds are handled via blob URLs in script.js
-// SW is registered for PWA install support and future use
+// Service Worker — app shell + offline support
+// Bump APP_CACHE version when static files change to force re-cache.
+// Bump SOUND_CACHE version when sound files change.
 
+const APP_CACHE_NAME = 'radio-app-v1';
 const CACHE_NAME = 'radio-images-v2';
-// Bump version when sound files change — activate handler cleans old versions.
 const SOUND_CACHE_NAME = 'radio-sounds-v1';
 const MAX_CACHED_IMAGES = 30;
+
+// App shell — everything needed to render the page offline
+const APP_SHELL = [
+  './',
+  './index.html',
+  './css/output.css',
+  './js/script.js',
+  './js/radioCore.js',
+  './js/stateMachine.js',
+  './js/keepAlive.js',
+  './manifest.json',
+  './images/favicon.png',
+  './images/logo.png',
+];
 
 const PRECACHE_SOUNDS = [
   './sounds/loading-low.mp3',
@@ -14,12 +28,15 @@ const PRECACHE_SOUNDS = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    (async () => {
-      const cache = await caches.open(SOUND_CACHE_NAME);
-      for (const url of PRECACHE_SOUNDS) {
-        try { await cache.add(url); } catch (_) { /* individual failure won't block install */ }
-      }
-    })()
+    Promise.all([
+      caches.open(APP_CACHE_NAME).then(cache => cache.addAll(APP_SHELL)),
+      (async () => {
+        const cache = await caches.open(SOUND_CACHE_NAME);
+        for (const url of PRECACHE_SOUNDS) {
+          try { await cache.add(url); } catch (_) { /* individual failure won't block install */ }
+        }
+      })(),
+    ])
   );
   self.skipWaiting();
 });
@@ -31,7 +48,7 @@ self.addEventListener('activate', (event) => {
       const keys = await caches.keys();
       await Promise.all(
         keys
-          .filter(k => k.startsWith('radio-') && k !== CACHE_NAME && k !== SOUND_CACHE_NAME)
+          .filter(k => k.startsWith('radio-') && k !== APP_CACHE_NAME && k !== CACHE_NAME && k !== SOUND_CACHE_NAME)
           .map(k => caches.delete(k))
       );
       await self.clients.claim();
@@ -48,7 +65,7 @@ async function trimCache() {
   }
 }
 
-// Serve cached Cloudinary images and sound files when offline (network-first)
+// Serve cached Cloudinary images, sound files, and app shell when offline
 self.addEventListener('fetch', (event) => {
   const url = event.request.url;
 
@@ -71,6 +88,30 @@ self.addEventListener('fetch', (event) => {
           return response;
         } catch (_) {
           return new Response('', { status: 503, statusText: 'Offline' });
+        }
+      })()
+    );
+    return;
+  }
+
+  // App shell — network-first, fallback to cache for offline
+  if (
+    event.request.method === 'GET' &&
+    reqUrl.origin === self.location.origin &&
+    !reqUrl.pathname.startsWith('/sounds/')
+  ) {
+    event.respondWith(
+      (async () => {
+        try {
+          const response = await fetch(event.request);
+          if (response.ok) {
+            const cache = await caches.open(APP_CACHE_NAME);
+            cache.put(event.request, response.clone());
+          }
+          return response;
+        } catch (_) {
+          const cached = await caches.match(event.request);
+          return cached || new Response('Offline', { status: 503, headers: { 'Content-Type': 'text/plain' } });
         }
       })()
     );

--- a/src/sw.js
+++ b/src/sw.js
@@ -29,7 +29,12 @@ const PRECACHE_SOUNDS = [
 self.addEventListener('install', (event) => {
   event.waitUntil(
     Promise.all([
-      caches.open(APP_CACHE_NAME).then(cache => cache.addAll(APP_SHELL)),
+      (async () => {
+        const cache = await caches.open(APP_CACHE_NAME);
+        for (const url of APP_SHELL) {
+          try { await cache.add(url); } catch (_) { /* individual failure won't block install */ }
+        }
+      })(),
       (async () => {
         const cache = await caches.open(SOUND_CACHE_NAME);
         for (const url of PRECACHE_SOUNDS) {

--- a/src/sw.js
+++ b/src/sw.js
@@ -3,9 +3,18 @@
 // SW is registered for PWA install support and future use
 
 const CACHE_NAME = 'radio-images-v2';
+const SOUND_CACHE_NAME = 'radio-sounds-v1';
 const MAX_CACHED_IMAGES = 30;
 
-self.addEventListener('install', () => {
+const PRECACHE_SOUNDS = [
+  './sounds/loading-low.mp3',
+  './sounds/error-low.mp3',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(SOUND_CACHE_NAME).then(cache => cache.addAll(PRECACHE_SOUNDS))
+  );
   self.skipWaiting();
 });
 
@@ -16,7 +25,7 @@ self.addEventListener('activate', (event) => {
       const keys = await caches.keys();
       await Promise.all(
         keys
-          .filter(k => k.startsWith('radio-') && k !== CACHE_NAME)
+          .filter(k => k.startsWith('radio-') && k !== CACHE_NAME && k !== SOUND_CACHE_NAME)
           .map(k => caches.delete(k))
       );
       await self.clients.claim();
@@ -33,9 +42,18 @@ async function trimCache() {
   }
 }
 
-// Serve cached Cloudinary images when offline (network-first)
+// Serve cached Cloudinary images and sound files when offline (network-first)
 self.addEventListener('fetch', (event) => {
   const url = event.request.url;
+
+  // Sound files — cache-first (pre-cached at install)
+  if (url.endsWith('.mp3') && event.request.method === 'GET') {
+    event.respondWith(
+      caches.match(event.request).then(cached => cached || fetch(event.request))
+    );
+    return;
+  }
+
   if (!url.includes('res.cloudinary.com') || event.request.method !== 'GET') return;
 
   event.respondWith(

--- a/src/sw.js
+++ b/src/sw.js
@@ -13,7 +13,12 @@ const PRECACHE_SOUNDS = [
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(SOUND_CACHE_NAME).then(cache => cache.addAll(PRECACHE_SOUNDS))
+    (async () => {
+      const cache = await caches.open(SOUND_CACHE_NAME);
+      for (const url of PRECACHE_SOUNDS) {
+        try { await cache.add(url); } catch (_) { /* individual failure won't block install */ }
+      }
+    })()
   );
   self.skipWaiting();
 });
@@ -46,10 +51,18 @@ async function trimCache() {
 self.addEventListener('fetch', (event) => {
   const url = event.request.url;
 
-  // Sound files — cache-first (pre-cached at install)
-  if (url.endsWith('.mp3') && event.request.method === 'GET') {
+  // Sound files — cache-first (pre-cached at install, same-origin /sounds/ only)
+  const reqUrl = new URL(url, self.location.origin);
+  if (
+    event.request.method === 'GET' &&
+    reqUrl.origin === self.location.origin &&
+    reqUrl.pathname.startsWith('/sounds/') &&
+    reqUrl.pathname.endsWith('.mp3')
+  ) {
     event.respondWith(
-      caches.match(event.request).then(cached => cached || fetch(event.request))
+      caches.open(SOUND_CACHE_NAME).then(cache =>
+        cache.match(event.request).then(cached => cached || fetch(event.request))
+      )
     );
     return;
   }

--- a/src/sw.js
+++ b/src/sw.js
@@ -2,7 +2,7 @@
 // Audio sounds are handled via blob URLs in script.js
 // SW is registered for PWA install support and future use
 
-const CACHE_NAME = 'radio-images';
+const CACHE_NAME = 'radio-images-v2';
 const MAX_CACHED_IMAGES = 30;
 
 self.addEventListener('install', () => {

--- a/src/sw.js
+++ b/src/sw.js
@@ -3,6 +3,7 @@
 // SW is registered for PWA install support and future use
 
 const CACHE_NAME = 'radio-images-v2';
+// Bump version when sound files change — activate handler cleans old versions.
 const SOUND_CACHE_NAME = 'radio-sounds-v1';
 const MAX_CACHED_IMAGES = 30;
 
@@ -60,9 +61,18 @@ self.addEventListener('fetch', (event) => {
     reqUrl.pathname.endsWith('.mp3')
   ) {
     event.respondWith(
-      caches.open(SOUND_CACHE_NAME).then(cache =>
-        cache.match(event.request).then(cached => cached || fetch(event.request))
-      )
+      (async () => {
+        const cache = await caches.open(SOUND_CACHE_NAME);
+        const cached = await cache.match(event.request);
+        if (cached) return cached;
+        try {
+          const response = await fetch(event.request);
+          if (response.ok) cache.put(event.request, response.clone());
+          return response;
+        } catch (_) {
+          return new Response('', { status: 503, statusText: 'Offline' });
+        }
+      })()
     );
     return;
   }

--- a/src/sw.js
+++ b/src/sw.js
@@ -84,7 +84,7 @@ self.addEventListener('fetch', (event) => {
         if (cached) return cached;
         try {
           const response = await fetch(event.request);
-          if (response.ok) cache.put(event.request, response.clone());
+          if (response.ok) await cache.put(event.request, response.clone());
           return response;
         } catch (_) {
           return new Response('', { status: 503, statusText: 'Offline' });
@@ -106,7 +106,7 @@ self.addEventListener('fetch', (event) => {
           const response = await fetch(event.request);
           if (response.ok) {
             const cache = await caches.open(APP_CACHE_NAME);
-            cache.put(event.request, response.clone());
+            await cache.put(event.request, response.clone());
           }
           return response;
         } catch (_) {

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
     {
       "source": "/sw.js",
       "headers": [
-        { "key": "Cache-Control", "value": "no-cache" }
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
       ]
     }
   ],

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,20 @@
 {
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    },
+    {
+      "source": "/sw.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache" }
+      ]
+    }
+  ],
   "routes": [
     { "src": "/(.*)", "dest": "/public/$1" }
   ]


### PR DESCRIPTION
Code review improvements across the radio PWA — resilience, offline behavior, production build, and mobile media session fixes.

### Recovery & resilience
- Add `MAX_RECOVERY_ATTEMPTS` (30) to cap silent recovery loops (~5 min) — prevents infinite retries when the network stays down
- Recovery counter resets on successful play, stop, or manual user interaction

### Offline support
- Pre-cache app shell (HTML, CSS, JS, images) with network-first strategy for full offline rendering
- Pre-cache sound files (`loading-low.mp3`, `error-low.mp3`) in SW install event
- Pre-cache station name images alongside status images in Cloudinary cache
- Add write-back on cache miss and graceful 503 fallback for sounds
- Eagerly preload sound blobs for returning users; preload + warmUp on prev/next clicks
- Fix race condition in `preloadBlob()` with a promise lock to prevent duplicate fetches

### Media session (mobile)
- Pause handler is now state-aware: stops radio (not just pause) during loading/error/recovering states
- Clear `setPositionState({})` on every SFX `timeupdate` tick so mobile OS never shows a countdown timer
- Use `setPositionState({})` consistently across all 5 call-sites (spec-compliant clearing)

### Build & deployment
- Switch from Terser CLI to Node API with guard for empty/errored output
- Drop only `console.log/info/debug` in production (keep `warn/error` for diagnostics)
- Bump image cache to `radio-images-v2`, add `radio-sounds-v1` and `radio-app-v1`
- Encode Cloudinary text overlay with `encodeURIComponent()`
- Add security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy)
- Add `Cache-Control: no-cache, no-store, must-revalidate` on `sw.js`

### Tests
- 7 new unit tests for recovery cap, reset, offline reschedule, and manual play override
- 1 new e2e test for offline-without-prior-play scenario (SW pre-cache verification)