### PR TITLE
Rework offline recovery: playback watchdog + endless backoff; user-level e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,38 @@ index.html          ← UI (butoane, poster, selector)
 
 ---
 
+## Recovery și offline
+
+Problema clasică pe net intermitent: stream-ul moare **fără niciun eveniment** (`error`/`stalled` nu se emit, mai ales pe HLS) și aplicația rămâne blocată — fie „cântă" liniște, fie stă în error pentru totdeauna. Soluția are trei piese, toate în `radioCore.js`:
+
+### 1. Watchdog pe progresul redării
+
+Singurul semnal de încredere e progresul efectiv: cât timp starea e `playing`, `player.currentTime` trebuie să avanseze. Un interval (`WATCHDOG_INTERVAL_MS` = 2s) compară valoarea; după `WATCHDOG_STALL_TICKS` (3) tick-uri înghețate consecutive (≈6s) → ciclul normal de retry/recovery. Zero falsuri pozitive pe HLS (currentTime avansează din buffer și între fetch-uri de segmente).
+
+> De ce nu evenimentul `stalled`? Browserele îl emit **și în timpul redării normale de HLS** (pauzele dintre segmente arată ca „stalled"), ceea ce producea flash-uri false de „Se încarcă..."; iar la înghețuri reale de multe ori nu se emite deloc. A fost eliminat complet.
+
+### 2. Recovery-ul nu renunță niciodată
+
+Backoff exponențial: 10s → 20s → 40s → plafonat la `RECOVERY_DELAY_MAX_MS` (60s), la infinit. (Vechiul plafon de 30 de încercări lăsa aplicația moartă în error după ~5 minute de net căzut — fatal pe net intermitent, unde `navigator.onLine` rămâne `true` și evenimentul `online` nu vine niciodată.)
+
+### 3. Offline explicit vs. „minciuna" lui `navigator.onLine`
+
+- `onLine === false` e de încredere → re-verificare fixă la 10s, fără să atingă rețeaua și fără escaladare de backoff; evenimentul `online` declanșează retry instant.
+- `onLine === true` poate fi fals pozitiv (WiFi fără internet) → se încearcă mereu; încercarea stream-ului e cea mai onestă probă de conectivitate.
+
+### Known issue: playerul HLS nativ din Chromium spamează request-uri
+
+Măsurat (iulie 2026, Chromium 145/149): un `<audio>` cu `.m3u8` atașat căruia îi tai rețeaua intră într-o buclă internă de retry pe playlist de **~4.700 req/s** (239k de request-uri în 60s), fără să emită vreun `error` și fără să se oprească singur. E comportament Chromium, nu al aplicației.
+
+- Aplicația **îl conține** în scenariul offline: watchdog → error → `playerSetSrc('')` detașează playerul și oprește spin-ul (măsurat: 2 request-uri în 45s de offline).
+- Net **lent** (nu tăiat) nu declanșează problema (măsurat: ~15 req/min la 30KB/s).
+- Fereastră rămasă: la reconectare, rar (1 din 3 în măsurători), spin-ul poate porni **în timp ce redarea merge normal** — caz invizibil pentru watchdog. Decizie: fără workaround deocamdată; opțiuni documentate — detector de spin cu `PerformanceObserver` pe resurse, sau hls.js lazy-load pe non-Safari.
+
+---
+
 ## Teste
 
-### Unit tests — `radioCore.test.js` (49 teste, Vitest)
+### Unit tests — `radioCore.test.js` (53 de teste, Vitest)
 
 Testează logica pură din `radioCore.js` **fără browser**. Toate dependențele (player, timere, DOM) sunt mock-uite manual prin `makeDeps()`.
 
@@ -109,10 +138,14 @@ Notă: dacă sumarul text afișează numere de linii lângă un fișier care are
 | **retrying keeps loading sound** | `keep` din `STATE_FX` | La `loading → retrying`, sunetul de loading continuă |
 | **togglePlayPause** | Un singur buton play/pause | Din `idle` pornește, din `playing` pauzează |
 | **restart after long pause** | Pauză > 2s → restart stream | Stream-urile radio nu bufferează, re-play după pauză lungă |
+| **recovery backoff** | Backoff exponențial fără plafon | 10s → 20s → 40s → 60s cap, mereu o încercare programată; offline: re-check fix la 10s |
+| **playback watchdog** | `currentTime` înghețat ≈6s → retry | Stall silențios detectat fără evenimente; progresul resetează numărătoarea; se oprește la pause/stop |
 
-### E2E tests — `e2e/radio.spec.js` (23 teste, Playwright)
+### E2E tests — `e2e/radio.spec.js` (35 de teste, Playwright)
 
-Testează aplicația completă în Chromium real. Stream-urile radio sunt interceptate și servite local (`test-tone.mp3`).
+Testează aplicația completă în Chromium real. Stream-urile radio sunt interceptate și servite local (`test-tone.mp3`, plus un playlist HLS mock cu segmente `.ts` reale pentru stația FIP — Chromium redă `.m3u8` nativ).
+
+**Principiu: testele văd ce vede utilizatorul.** Toate interacțiunile trec prin roluri accesibile (`getByRole`, helper-ul `ui()`), iar asertările se fac pe text vizibil, titlul paginii (numele stației + ⏳/🔴/❤️‍🩹) și starea butoanelor — niciodată pe id-uri, clase CSS sau stare internă. Excepțiile white-box (ex. versionarea cache-ului de sunete) sunt marcate și justificate în comentarii.
 
 ```bash
 npm run test:e2e  # playwright test
@@ -121,22 +154,24 @@ npm run test:e2e  # playwright test
 | Grup | Test | Ce verifică |
 |---|---|---|
 | **Page load** | page loads with correct title and idle state | Title, play button vizibil, pause/stop ascunse |
-| | all radio station buttons are rendered in selector | 18 butoane în dropdown |
-| **Play/Pause/Stop** | clicking play starts loading, then plays | `loading → playing`, poster se schimbă |
+| | all radio station buttons are rendered in selector | 19 butoane în dropdown (`STATION_COUNT`) |
+| **Play/Pause/Stop** | clicking play starts playback | Pause vizibil, mesaj de loading ascuns, titlu 🔴 |
 | | clicking stop returns to idle | Stop → play button revine |
-| **Station switching** | clicking next changes station | Poster se schimbă la stație diferită |
-| | clicking prev wraps to last station from first | Prev din Kiss FM → Vanilla Radio Fresh |
-| **Selector UI** | selecting a station from dropdown starts playing | Click pe Europa FM → loading/playing |
+| **Station switching** | clicking next changes station | Titlul arată noua stație (Europa FM) |
+| | clicking prev wraps to last station from first | Prev din Kiss FM → FIP Radio France (ultima) |
+| **HLS** | a transient stall on the HLS station does not interrupt playback | `stalled` sintetic în timpul redării FIP → fără flash de loading/error |
+| | recovers by itself after the connection drops and comes back | Rețeaua cade → bufferul se scurge → îngheț silențios → watchdog → reconectare automată, fără click |
+| **Selector UI** | selecting a station from dropdown starts playing | Click pe Europa FM → playing, titlul confirmă |
 | | clicking outside closes the selector | Click pe body → dropdown se închide |
-| **Error state** | shows error state when stream fails | Stream abortat → error msg vizibil + stop button |
-| **Persistence** | saves and restores last played station | localStorage `lastRadioIndex` supraviețuiește reload |
-| **Loading msg** | loading message appears during stream connection | Text "Se încarcă... Kiss FM" vizibil |
+| **Error state** | shows error state when stream fails | Stream abortat → „Eroare la încărcarea…" vizibil + stop button |
+| **Persistence** | saves and restores last played station | După reload, titlul arată stația restaurată |
+| **Loading msg** | loading message appears during stream connection | Text „Se încarcă... Kiss FM" vizibil |
 | **Accessibility** | all control buttons have aria-labels | 6 butoane cu `aria-label` |
-| | page has a main landmark | `<main>` prezent |
-| **Offline — imagini** | all 3 status images are pre-cached on page load | Cache API conține idle + loading + error |
-| | error and idle images render offline via SW cache | Offline → error poster loaded (`naturalWidth > 0`) |
-| **Offline — sunete** | error sound plays offline from preloaded blob | Offline → error → `errorNoise.src` = `blob:`, nu e paused |
-| | loading sound plays from preloaded blob | Stream blocat → loading → `loadingNoise.src` = `blob:` |
+| | page has a main landmark | `main` prezent (rol landmark) |
+| **Offline — imagini** | all 3 status images are fetched on page load | Idle + loading + error descărcate pentru offline |
+| | error and idle images render offline via SW cache | Offline → poster randat (`naturalWidth > 0`) |
+| **Offline — sunete** | error sound plays while offline | Sunetul cântă, zero request-uri de rețea pentru sunete |
+| | loading sound plays while the next station is still connecting | Sunetul de loading cântă instant, fără rețea |
 
 ### Cum se leagă
 

--- a/e2e/radio.spec.js
+++ b/e2e/radio.spec.js
@@ -3,6 +3,7 @@ import { test, expect } from '@playwright/test';
 const STREAM_URL_RE = /live\.kissfm|europafm|digifm|magicfm|virginradio|srr\.ro|profm|rockfm|guerrillaradio|nationalfm|dancefm|radiovibefm|radioprob|vanillaradio|radiofrance|\/accs3\/fip\/test-tone-\d+\.ts/;
 const SOUND_URL_RE = /\/sounds\/(?:loading-low|error-low)\.mp3(?:\?.*)?$/;
 const SOUND_CACHE_NAME = 'radio-sounds-v1';
+const STATION_COUNT = 19;
 const HLS_TEST_SEGMENT = Buffer.from(
   'R0AREABC8CUAAcEAAP8B/wAB/IAUSBIBBkZGbXBlZwlTZXJ2aWNlMDF3fEPK//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////9HQAAQAACwDQABwQAAAAHwACqxBLL//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////0dQABAAArASAAHBAADhAPAAD+EA8AC2m8DZ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////R0EAMAdQAAB7DH4AAAABwADpgIAFIQAH2GH/8VCAA9/83gIATGF2YzYyLjI4LjEwMgBCIAjBGDj/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FHAQAxeAD//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////1CAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHEdAABEAALANAAHBAAAAAfAAKrEEsv//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////R1AAEQACsBIAAcEAAOEA8AAP4QDwALabwNn///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////9HQQAyB1AAALxa/gAAAAHAANiAgAUhAAndm//xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb0cBADOJAP/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwcR0AREQBC8CUAAcEAAP8B/wAB/IAUSBIBBkZGbXBlZwlTZXJ2aWNlMDF3fEPK//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////9HQAASAACwDQABwQAAAAHwACqxBLL//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////0dQABIAArASAAHBAADhAPAAD+EA8AC2m8DZ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////R0EANAdQAAD9qX4AAAABwADYgIAFIQAL4tX/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb9HAQA1iQD//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHEdAABMAALANAAHBAAAAAfAAKrEEsv//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////R1AAEwACsBIAAcEAAOEA8AAP4QDwALabwNn///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////9HQQA2J1AAAT73fgD//////////////////////////////////////////wAAAcAAioCABSEADegN//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHP/xUIABv/whEARgjBz/8VCAAb/8IRAEYIwc//FQgAG//CEQBGCMHA==',
   'base64',
@@ -57,6 +58,46 @@ async function mockStreamsError(page) {
   });
 }
 
+// Helper: streams answer only after a delay, so the loading state lasts long
+// enough to interact with.
+async function mockStreamsDelayed(page, delayMs) {
+  await page.route(STREAM_URL_RE, async (route) => {
+    await new Promise(r => setTimeout(r, delayMs));
+    await route.fulfill({
+      status: 200,
+      contentType: 'audio/mpeg',
+      path: 'src/sounds/test-tone.mp3',
+    });
+  });
+}
+
+// Helper: streams never answer — the app stays in loading.
+async function mockStreamsHang(page) {
+  await page.route(STREAM_URL_RE, () => { /* never respond */ });
+}
+
+// --- User-facing locators ---
+// Tests interact through accessible roles/names and visible text — the same
+// things a user (or screen reader) perceives, never ids or CSS classes.
+function ui(page) {
+  return {
+    playButton:     page.getByRole('button', { name: 'Redare' }),
+    pauseButton:    page.getByRole('button', { name: 'Pauză' }),
+    stopButton:     page.getByRole('button', { name: 'Oprește' }),
+    prevButton:     page.getByRole('button', { name: 'Postul anterior' }),
+    nextButton:     page.getByRole('button', { name: 'Postul următor' }),
+    stationPicker:  page.getByRole('button', { name: 'Alege postul de radio' }),
+    posterButton:   page.getByRole('button', { name: 'Deschide selectorul de posturi' }),
+    logoButton:     page.getByRole('button', { name: 'Reîncarcă pagina' }),
+    stationList:    page.getByRole('listbox', { name: 'Posturi de radio' }),
+    stationOptions: page.getByRole('listbox', { name: 'Posturi de radio' }).getByRole('option'),
+    loadingMsg:     page.getByText(/Se încarcă/),
+    errorMsg:       page.getByText(/Eroare la încărcarea/),
+  };
+}
+
+// Synchronization only (not an assertion): wait until the app finished its
+// sound preload so later steps aren't racing page init.
 async function waitForSoundBlobs(page) {
   await page.waitForFunction(() =>
     ['loadingNoise', 'errorNoise'].every((id) =>
@@ -75,10 +116,12 @@ async function blockLateSoundRequests(page) {
   return lateSoundRequests;
 }
 
-async function expectSoundPlayingFromBlob(page, id) {
+// A user "hears" a sound — the closest observable signal in a headless test
+// is that its <audio> element is actively playing.
+async function expectSoundPlaying(page, id) {
   await page.waitForFunction((audioId) => {
     const el = document.getElementById(audioId);
-    return Boolean(el && !el.paused && el.src.startsWith('blob:'));
+    return Boolean(el && !el.paused);
   }, id, { timeout: 3000 });
 }
 
@@ -98,366 +141,414 @@ test.describe('Radio Player E2E', () => {
   // --- Page load ---
 
   test('page loads with correct title and idle state', async ({ page }) => {
+    const c = ui(page);
     await page.goto('/');
     await expect(page).toHaveTitle(/Radio Player|Coji/);
-    await expect(page.locator('#playButton')).toBeVisible();
-    await expect(page.locator('#pauseButton')).toBeHidden();
-    await expect(page.locator('#stopButton')).toBeHidden();
+    await expect(c.playButton).toBeVisible();
+    await expect(c.pauseButton).toBeHidden();
+    await expect(c.stopButton).toBeHidden();
   });
 
   test('play button is focused on first load so Enter starts playback', async ({ page }) => {
+    const c = ui(page);
     await mockStreams(page);
     await page.goto('/');
 
-    await expect(page.getByLabel('Redare')).toBeFocused();
+    await expect(c.playButton).toBeFocused();
     await page.keyboard.press('Enter');
-    await expect(page.getByLabel('Pauză')).toBeFocused({ timeout: 8000 });
+    await expect(c.pauseButton).toBeFocused({ timeout: 8000 });
   });
 
   test('all radio station buttons are rendered in selector', async ({ page }) => {
+    const c = ui(page);
     await page.goto('/');
-    await page.getByLabel('Alege postul de radio').click();
-    await expect(page.getByRole('listbox', { name: 'Posturi de radio' }).getByRole('option')).toHaveCount(19);
+    await c.stationPicker.click();
+    await expect(c.stationOptions).toHaveCount(STATION_COUNT);
   });
 
   // --- Play / Pause / Stop ---
 
-  test('clicking play starts loading, then plays', async ({ page }) => {
+  test('clicking play starts playback', async ({ page }) => {
+    const c = ui(page);
     await mockStreams(page);
     await page.goto('/');
 
-    await page.locator('#playButton').click();
+    await c.playButton.click();
 
-    // Should transition to loading → show stop button
-    await expect(page.locator('#stopButton')).toBeVisible({ timeout: 3000 });
-
-    // Wait for playing state (stop button stays visible while playing)
-    // The poster image should update away from idle
-    await expect(page.locator('#posterImage img')).not.toHaveAttribute(
-      'src', /Coji%20Radio%20Player/, { timeout: 8000 }
-    );
+    // Playing: pause control appears, loading message gone, live dot in title
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
+    await expect(c.loadingMsg).toBeHidden();
+    await expect(page).toHaveTitle(/🔴/);
   });
 
   test('clicking stop returns to idle', async ({ page }) => {
+    const c = ui(page);
     // Delay stream response so loading state lasts long enough to click stop
-    await page.route(STREAM_URL_RE, async (route) => {
-      await new Promise(r => setTimeout(r, 2000));
-      await route.fulfill({
-        status: 200,
-        contentType: 'audio/mpeg',
-        path: 'src/sounds/test-tone.mp3',
-      });
-    });
+    await mockStreamsDelayed(page, 2000);
     await page.goto('/');
 
-    await page.locator('#playButton').click();
-    await expect(page.locator('#stopButton')).toBeVisible({ timeout: 3000 });
+    await c.playButton.click();
+    await expect(c.stopButton).toBeVisible({ timeout: 3000 });
 
-    await page.locator('#stopButton').click();
-    await expect(page.locator('#playButton')).toBeVisible();
-    await expect(page.locator('#stopButton')).toBeHidden();
+    await c.stopButton.click();
+    await expect(c.playButton).toBeVisible();
+    await expect(c.stopButton).toBeHidden();
   });
 
   test('keyboard focus stays in the center playback controls', async ({ page }) => {
+    const c = ui(page);
     await mockStreams(page);
     await page.goto('/');
 
-    await page.getByLabel('Redare').focus();
+    await c.playButton.focus();
     await page.keyboard.press('Enter');
-    await expect(page.getByLabel('Pauză')).toBeFocused({ timeout: 8000 });
+    await expect(c.pauseButton).toBeFocused({ timeout: 8000 });
 
     await page.keyboard.press('Enter');
-    await expect(page.getByLabel('Redare')).toBeFocused();
+    await expect(c.playButton).toBeFocused();
   });
 
   test('keyboard focus returns to play after stopping from the center control', async ({ page }) => {
-    await page.route(STREAM_URL_RE, async (route) => {
-      await new Promise(r => setTimeout(r, 2000));
-      await route.fulfill({
-        status: 200,
-        contentType: 'audio/mpeg',
-        path: 'src/sounds/test-tone.mp3',
-      });
-    });
+    const c = ui(page);
+    await mockStreamsDelayed(page, 2000);
     await page.goto('/');
 
-    await page.getByLabel('Redare').focus();
+    await c.playButton.focus();
     await page.keyboard.press('Enter');
-    await expect(page.getByLabel('Oprește')).toBeFocused({ timeout: 3000 });
+    await expect(c.stopButton).toBeFocused({ timeout: 3000 });
 
     await page.keyboard.press('Enter');
-    await expect(page.getByLabel('Redare')).toBeFocused();
+    await expect(c.playButton).toBeFocused();
   });
 
   // --- Station switching ---
 
   test('clicking next changes station', async ({ page }) => {
+    const c = ui(page);
     await mockStreams(page);
     await page.goto('/');
 
-    // Start playing and wait for playing state (poster shows station name)
-    await page.locator('#playButton').click();
-    await expect(page.locator('#pauseButton')).toBeVisible({ timeout: 8000 });
+    await c.playButton.click();
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
+    await expect(page).toHaveTitle(/Kiss FM/);
 
-    // Get initial poster (now shows actual station name, not loading text)
-    const initialSrc = await page.locator('#posterImage img').getAttribute('src');
+    await c.nextButton.click();
 
-    // Click next
-    await page.locator('#nextButton').click();
-
-    // Wait for poster to change to a different station
-    await expect(page.locator('#posterImage img')).not.toHaveAttribute('src', initialSrc, { timeout: 8000 });
+    // The next station's name shows up in the title (while loading and playing)
+    await expect(page).toHaveTitle(/Europa FM/, { timeout: 8000 });
   });
 
   test('clicking prev wraps to last station from first', async ({ page }) => {
+    const c = ui(page);
     await mockStreams(page);
     await page.goto('/');
 
-    await page.locator('#playButton').click();
-    await expect(page.locator('#pauseButton')).toBeVisible({ timeout: 8000 });
+    await c.playButton.click();
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
 
-    // Click prev — should wrap from station 0 to station 18 (last = FIP Radio France)
-    await page.locator('#prevButton').click();
+    // Prev from the first station should wrap to the last one (FIP Radio France)
+    await c.prevButton.click();
+    await expect(page).toHaveTitle(/FIP/, { timeout: 8000 });
+  });
 
-    // Wait for poster to update to last station
-    await expect(page.locator('#posterImage img')).toHaveAttribute('src', /FIP/, { timeout: 8000 });
+  test('a transient stall on the HLS station does not interrupt playback', async ({ page }) => {
+    const c = ui(page);
+    await mockStreams(page);
+    await page.goto('/');
 
+    // Play the HLS station (FIP) the way a user would: pick it from the selector
+    await c.stationPicker.click();
+    await page.getByRole('option', { name: 'FIP Radio France' }).click();
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
+
+    // Browsers routinely emit 'stalled' between HLS segment fetches even when
+    // playback is fine. Simulate that browser-level event and make sure the
+    // player does NOT flash into loading/error while audio keeps playing.
     await page.locator('#player').evaluate((player) => {
       player.dispatchEvent(new Event('stalled'));
     });
     await page.waitForTimeout(5500);
 
-    await expect(page.locator('#posterImage img')).toHaveAttribute('src', /FIP/);
-    await expect(page.locator('#loadingMsg')).toHaveClass(/invisible/);
-    await expect(page.locator('#errorMsg')).toHaveClass(/invisible/);
+    await expect(c.pauseButton).toBeVisible();
+    await expect(c.loadingMsg).toBeHidden();
+    await expect(c.errorMsg).toBeHidden();
+    await expect(page).toHaveTitle(/FIP/);
+  });
+
+  test('recovers by itself after the connection drops and comes back (HLS)', async ({ page }) => {
+    // Real timings: ~12s of buffer drains, watchdog notices (~6s), retry
+    // cycle runs, then recovery reconnects once the network is back.
+    test.setTimeout(120_000);
+    const c = ui(page);
+
+    // Same mock as mockStreams, plus a switch that simulates the connection
+    // dropping: every stream request just hangs.
+    let connectionDown = false;
+    await page.route(STREAM_URL_RE, async (route) => {
+      if (connectionDown) return; // nothing answers anymore
+      const url = route.request().url();
+      if (url.endsWith('.m3u8')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/vnd.apple.mpegurl',
+          body: [
+            '#EXTM3U',
+            '#EXT-X-VERSION:3',
+            '#EXT-X-MEDIA-SEQUENCE:349685',
+            '#EXT-X-TARGETDURATION:4',
+            '#EXT-X-START:TIME-OFFSET=0',
+            '#EXTINF:4.000,',
+            '/accs3/fip/test-tone-349685.ts',
+            '#EXTINF:4.000,',
+            '/accs3/fip/test-tone-349686.ts',
+            '#EXTINF:4.000,',
+            '/accs3/fip/test-tone-349687.ts',
+          ].join('\n'),
+        });
+        return;
+      }
+      if (url.includes('/accs3/fip/test-tone-')) {
+        await route.fulfill({ status: 200, contentType: 'video/mp2t', body: HLS_TEST_SEGMENT });
+        return;
+      }
+      await route.fulfill({ status: 200, contentType: 'audio/mpeg', path: 'src/sounds/test-tone.mp3' });
+    });
+
+    await page.goto('/');
+    await c.stationPicker.click();
+    await page.getByRole('option', { name: 'FIP Radio France' }).click();
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
+
+    // The connection drops: playlist refreshes and segments stop answering.
+    // The buffered audio drains, playback silently freezes — the app must
+    // notice on its own (no 'error' event fires in this scenario).
+    connectionDown = true;
+    await expect(page).toHaveTitle(/⏳|❤️‍🩹/, { timeout: 45000 });
+
+    // The connection comes back — the app must recover without any click
+    connectionDown = false;
+    await expect(c.pauseButton).toBeVisible({ timeout: 45000 });
+    await expect(page).toHaveTitle(/🔴/);
+    await expect(page).toHaveTitle(/FIP/);
   });
 
   // --- Station selector UI ---
 
   test('selecting a station from dropdown starts playing it', async ({ page }) => {
+    const c = ui(page);
     await mockStreams(page);
     await page.goto('/');
 
-    // Open selector
-    await page.locator('#new_selector__button').click();
-    await expect(page.locator('#new_selector__content')).toBeVisible();
+    await c.stationPicker.click();
+    await expect(c.stationList).toBeVisible();
 
-    // Pick "Europa FM" (2nd station)
     await page.getByRole('option', { name: 'Europa FM' }).click();
 
-    // Selector should close
-    await expect(page.locator('#new_selector__content')).toBeHidden();
-
-    // Should be loading/playing
-    await expect(page.locator('#stopButton')).toBeVisible({ timeout: 3000 });
+    // Selector closes and the chosen station starts playing
+    await expect(c.stationList).toBeHidden();
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
+    await expect(page).toHaveTitle(/Europa FM/);
   });
 
   test('clicking outside closes the selector', async ({ page }) => {
+    const c = ui(page);
     await page.goto('/');
 
-    await page.locator('#new_selector__button').click();
-    await expect(page.locator('#new_selector__content')).toBeVisible();
+    await c.stationPicker.click();
+    await expect(c.stationList).toBeVisible();
 
     // Click on body (outside selector)
     await page.locator('body').click({ position: { x: 10, y: 10 } });
-    await expect(page.locator('#new_selector__content')).toBeHidden();
+    await expect(c.stationList).toBeHidden();
   });
 
   test('Escape closes the selector after opening it with the mouse', async ({ page }) => {
+    const c = ui(page);
     await page.goto('/');
 
-    await page.getByLabel('Alege postul de radio').click();
-    await expect(page.locator('#new_selector__content')).toBeVisible();
+    await c.stationPicker.click();
+    await expect(c.stationList).toBeVisible();
 
     await page.keyboard.press('Escape');
-    await expect(page.locator('#new_selector__content')).toBeHidden();
+    await expect(c.stationList).toBeHidden();
   });
 
   test('keyboard arrows navigate the selector after opening it with the mouse', async ({ page }) => {
+    const c = ui(page);
     await mockStreams(page);
     await page.goto('/');
 
-    const stationPicker = page.getByLabel('Alege postul de radio');
-    const poster = page.locator('#posterImage img');
-    const options = page.getByRole('listbox', { name: 'Posturi de radio' }).getByRole('option');
-
-    await stationPicker.click();
-    await expect(page.locator('#new_selector__content')).toBeVisible();
-    await expect(options.first()).toBeFocused();
+    await c.stationPicker.click();
+    await expect(c.stationList).toBeVisible();
+    await expect(c.stationOptions.first()).toBeFocused();
 
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
 
-    await expect(poster).toHaveAttribute('src', /Europa/, { timeout: 8000 });
-    await expect(stationPicker).toBeFocused();
+    await expect(page).toHaveTitle(/Europa/, { timeout: 8000 });
+    await expect(c.stationPicker).toBeFocused();
   });
 
   test('opening selector focuses the selected station', async ({ page }) => {
+    const c = ui(page);
+    await page.addInitScript(() => {
+      localStorage.setItem('lastRadioIndex', '2');
+    });
     await page.goto('/');
 
-    const stationPicker = page.getByLabel('Alege postul de radio');
-    const options = page.getByRole('listbox', { name: 'Posturi de radio' }).getByRole('option');
-
-    await page.evaluate(() => localStorage.setItem('lastRadioIndex', '2'));
-    await page.reload();
-
-    await stationPicker.click();
-    await expect(page.locator('#new_selector__content')).toBeVisible();
-    await expect(options.nth(2)).toBeFocused();
+    await c.stationPicker.click();
+    await expect(c.stationList).toBeVisible();
+    await expect(c.stationOptions.nth(2)).toBeFocused();
   });
 
   test('ArrowDown keeps the closed selector available for remote focus navigation', async ({ page }) => {
+    const c = ui(page);
     await page.goto('/');
 
-    const stationPicker = page.getByLabel('Alege postul de radio');
-    const selector = page.locator('#new_selector__content');
-
-    await stationPicker.focus();
+    await c.stationPicker.focus();
     await page.keyboard.press('ArrowDown');
 
-    await expect(selector).toBeHidden();
+    await expect(c.stationList).toBeHidden();
   });
 
   test('keyboard users can open and navigate the selector from the poster', async ({ page }) => {
+    const c = ui(page);
     await mockStreams(page);
     await page.goto('/');
 
-    const poster = page.locator('#posterImage img');
-    const posterButton = page.getByRole('button', { name: 'Deschide selectorul de posturi', exact: true });
-
-    await expect(posterButton).toHaveAttribute('aria-expanded', 'false');
-    await posterButton.focus();
+    await expect(c.posterButton).toHaveAttribute('aria-expanded', 'false');
+    await c.posterButton.focus();
     await page.keyboard.press('Enter');
-    await expect(page.locator('#new_selector__content')).toBeVisible();
-    await expect(posterButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(c.stationList).toBeVisible();
+    await expect(c.posterButton).toHaveAttribute('aria-expanded', 'true');
 
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
 
-    await expect(poster).toHaveAttribute('src', /Europa/, { timeout: 8000 });
-    await expect(posterButton).toHaveAttribute('aria-expanded', 'false');
-    await expect(posterButton).toBeFocused();
+    await expect(page).toHaveTitle(/Europa/, { timeout: 8000 });
+    await expect(c.posterButton).toHaveAttribute('aria-expanded', 'false');
+    await expect(c.posterButton).toBeFocused();
   });
 
   test('keyboard users can reload the page from the logo', async ({ page }) => {
+    const c = ui(page);
     await page.goto('/');
 
-    const logoButton = page.getByLabel('Reîncarcă pagina');
-    await logoButton.focus();
+    await c.logoButton.focus();
 
     await Promise.all([
-      page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+      page.waitForEvent('load'),
       page.keyboard.press('Enter'),
     ]);
 
-    await expect(page).toHaveURL(/\/$/);
+    // Back to a fresh idle page
+    await expect(c.playButton).toBeVisible();
   });
 
   test('keyboard users can select a station and dismiss without changing selection', async ({ page }) => {
+    const c = ui(page);
     await mockStreams(page);
     await page.goto('/');
 
-    const stationPicker = page.getByLabel('Alege postul de radio');
-    const poster = page.locator('#posterImage img');
-
-    await stationPicker.focus();
+    await c.stationPicker.focus();
     await page.keyboard.press('Enter');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
 
-    await expect(poster).toHaveAttribute('src', /Europa/, { timeout: 8000 });
-    await expect(stationPicker).toBeFocused();
+    await expect(page).toHaveTitle(/Europa/, { timeout: 8000 });
+    await expect(c.stationPicker).toBeFocused();
 
-    await stationPicker.focus();
+    await c.stationPicker.focus();
     await page.keyboard.press('Enter');
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Escape');
 
-    await expect(poster).toHaveAttribute('src', /Europa/);
+    // Dismissing without choosing keeps the current station
+    await expect(page).toHaveTitle(/Europa/);
   });
 
   test('ArrowLeft and ArrowRight close the open selector', async ({ page }) => {
+    const c = ui(page);
     await page.goto('/');
 
-    const stationPicker = page.getByLabel('Alege postul de radio');
-
-    await stationPicker.focus();
+    await c.stationPicker.focus();
     await page.keyboard.press('Enter');
-    await expect(page.locator('#new_selector__content')).toBeVisible();
+    await expect(c.stationList).toBeVisible();
     await page.keyboard.press('ArrowRight');
-    await expect(page.locator('#new_selector__content')).toBeHidden();
-    await expect(stationPicker).toBeFocused();
+    await expect(c.stationList).toBeHidden();
+    await expect(c.stationPicker).toBeFocused();
 
     await page.keyboard.press('Enter');
-    await expect(page.locator('#new_selector__content')).toBeVisible();
+    await expect(c.stationList).toBeVisible();
     await page.keyboard.press('ArrowLeft');
-    await expect(page.locator('#new_selector__content')).toBeHidden();
-    await expect(stationPicker).toBeFocused();
+    await expect(c.stationList).toBeHidden();
+    await expect(c.stationPicker).toBeFocused();
   });
 
   // --- Error state ---
 
   test('shows error state when stream fails', async ({ page }) => {
+    const c = ui(page);
     await mockStreamsError(page);
     await page.goto('/');
 
-    await page.locator('#playButton').click();
+    await c.playButton.click();
 
     // Should eventually show error message (after retry cycle)
     // Retry cycle: loading(6s) + retry delay(3s) + loading(6s) = ~15s worst case
-    await expect(page.locator('#errorMsg')).not.toHaveClass(/invisible/, { timeout: 25000 });
+    await expect(c.errorMsg).toBeVisible({ timeout: 25000 });
 
     // In error state, stop button is visible (error/recovering both show stop)
-    await expect(page.locator('#stopButton')).toBeVisible();
+    await expect(c.stopButton).toBeVisible();
   });
 
   // --- localStorage persistence ---
 
   test('saves and restores last played station', async ({ page }) => {
+    const c = ui(page);
     await mockStreams(page);
     await page.goto('/');
 
     // Open selector and pick "Digi FM" (3rd station, index 2)
-    await page.getByLabel('Alege postul de radio').click();
+    await c.stationPicker.click();
     await page.getByRole('option', { name: 'Digi FM' }).click();
 
-    // Wait for playing state — saveLastIndex is called only when playing starts
-    await expect(page.locator('#pauseButton')).toBeVisible({ timeout: 8000 });
+    // Wait for playing state — the station is only remembered once it plays
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
 
-    // Reload page
     await page.reload();
 
-    // Poster should show Digi FM (restored from localStorage, idle shows station title)
-    await expect(page.locator('#posterImage img')).toHaveAttribute('src', /Digi/, { timeout: 5000 });
+    // The restored station shows in the title while idle, ready to play
+    await expect(page).toHaveTitle(/Digi FM/, { timeout: 5000 });
+    await expect(c.playButton).toBeVisible();
   });
 
   test('ignores invalid saved station index', async ({ page }) => {
+    const c = ui(page);
     await page.addInitScript(() => {
       localStorage.setItem('lastRadioIndex', '999');
     });
     await page.goto('/');
 
-    await expect(page.locator('#playButton')).toBeVisible();
-    await expect(page.locator('#posterImage img')).toHaveAttribute('src', /Coji%20Radio%20Player/);
+    await expect(c.playButton).toBeVisible();
+    await expect(page).toHaveTitle(/Coji Radio Player/);
 
-    await page.getByLabel('Alege postul de radio').click();
-    await expect(page.getByRole('listbox', { name: 'Posturi de radio' }).getByRole('option')).toHaveCount(19);
+    await c.stationPicker.click();
+    await expect(c.stationOptions).toHaveCount(STATION_COUNT);
   });
 
   // --- Loading / Error messages ---
 
   test('loading message appears during stream connection', async ({ page }) => {
-    // Use a slow route to keep it in loading state
-    await page.route(/live\.kissfm/, (route) => {
-      // Never respond — stays in loading
-      // (Playwright will clean up when test ends)
-    });
+    const c = ui(page);
+    // Streams never answer — the app stays in the loading state
+    await mockStreamsHang(page);
     await page.goto('/');
 
-    await page.locator('#playButton').click();
+    await c.playButton.click();
 
-    await expect(page.locator('#loadingMsg')).not.toHaveClass(/invisible/, { timeout: 3000 });
-    expect(await page.locator('#loadingMsg').innerText()).toContain('Kiss FM');
+    await expect(c.loadingMsg).toBeVisible({ timeout: 3000 });
+    await expect(c.loadingMsg).toContainText('Kiss FM');
   });
 
   // --- Accessibility ---
@@ -473,7 +564,7 @@ test.describe('Radio Player E2E', () => {
 
   test('page has a main landmark', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('main')).toBeVisible();
+    await expect(page.getByRole('main')).toBeVisible();
   });
 });
 
@@ -496,9 +587,22 @@ test.describe('Offline — cached resources', () => {
     'base64',
   );
 
+  test.beforeEach(async ({ page }) => {
+    await page.route(/res\.cloudinary\.com/, (route) =>
+      route.fulfill({ status: 200, contentType: 'image/png', body: PIXEL_PNG }));
+  });
+
+  // The poster is the user's main visual feedback — it must render even offline.
+  async function expectPosterRendered(page) {
+    await page.waitForFunction(() => {
+      const img = document.querySelector('#posterImage img');
+      return img.complete && img.naturalWidth > 0;
+    }, { timeout: 5000 });
+  }
+
   // --- Images ---
 
-  test('all 3 status images are pre-cached on page load', async ({ page }) => {
+  test('all 3 status images are fetched on page load so they can work offline', async ({ page }) => {
     const fetchedUrls = [];
     await page.route(/res\.cloudinary\.com/, (route) => {
       fetchedUrls.push(route.request().url());
@@ -506,126 +610,102 @@ test.describe('Offline — cached resources', () => {
     });
 
     await page.goto('/');
-    await page.waitForTimeout(2000);
 
     for (const text of Object.values(LABELS)) {
       const encoded = encodeURIComponent(text);
-      expect(fetchedUrls.some(u => u.includes(text) || u.includes(encoded)),
-        `should fetch image for "${text}"`).toBe(true);
+      await expect
+        .poll(() => fetchedUrls.some(u => u.includes(text) || u.includes(encoded)), {
+          message: `should fetch image for "${text}"`,
+          timeout: 5000,
+        })
+        .toBe(true);
     }
   });
 
   test('error and idle images render offline via SW cache', async ({ page }) => {
-    await page.route(/res\.cloudinary\.com/, (route) =>
-      route.fulfill({ status: 200, contentType: 'image/png', body: PIXEL_PNG }));
+    const c = ui(page);
     await mockStreams(page);
 
     await page.goto('/');
 
-    // Play a station so images have time to be cached via Cache API / SW
-    await page.locator('#playButton').click();
-    await expect(page.locator('#pauseButton')).toBeVisible({ timeout: 8000 });
-    await page.waitForTimeout(2000);
+    // Play a station, then wait (synchronization only) until the status
+    // images actually landed in the cache before cutting the network.
+    await c.playButton.click();
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
+    await page.waitForFunction(async (count) => {
+      const cache = await caches.open('radio-images-v2');
+      return (await cache.keys()).length >= count;
+    }, STATION_COUNT + 3, { timeout: 10000 });
 
     await page.context().setOffline(true);
 
     // --- Error image (nextButton offline → error state) ---
-    await page.locator('#nextButton').click();
-    await expect(page.locator('#errorMsg')).not.toHaveClass(/invisible/, { timeout: 3000 });
+    await c.nextButton.click();
+    await expect(c.errorMsg).toBeVisible({ timeout: 3000 });
+    await expectPosterRendered(page);
 
-    // Image should still load offline (served from SW cache)
-    await page.waitForFunction(() => {
-      const img = document.querySelector('#posterImage img');
-      return img.complete && img.naturalWidth > 0;
-    }, { timeout: 5000 });
-
-    // --- Idle / default image (stop → idle with no restored station) ---
-    await page.locator('#stopButton').click();
-    await expect(page.locator('#playButton')).toBeVisible();
-
-    await page.waitForFunction(() => {
-      const img = document.querySelector('#posterImage img');
-      return img.complete && img.naturalWidth > 0;
-    }, { timeout: 5000 });
+    // --- Idle / default image (stop → idle) ---
+    await c.stopButton.click();
+    await expect(c.playButton).toBeVisible();
+    await expectPosterRendered(page);
   });
 
   // --- Sounds ---
+  // A headless test can't literally *hear* the loading/error feedback, so
+  // these observe the closest user-level signals: the sound is actively
+  // playing, and no network was needed to play it.
 
-  test('preloads loading and error sounds into blob memory on page load', async ({ page }) => {
-    await page.route(/res\.cloudinary\.com/, (route) =>
-      route.fulfill({ status: 200, contentType: 'image/png', body: PIXEL_PNG }));
-
-    await page.goto('/');
-    await waitForSoundBlobs(page);
-
-    const blobStates = await page.evaluate(() => ({
-      loading: document.getElementById('loadingNoise').dataset.blobReady,
-      error: document.getElementById('errorNoise').dataset.blobReady,
-    }));
-
-    expect(blobStates).toEqual({ loading: 'true', error: 'true' });
-  });
-
-  test('loading sound uses preloaded blob on first play without late sound network', async ({ page }) => {
-    await page.route(/res\.cloudinary\.com/, (route) =>
-      route.fulfill({ status: 200, contentType: 'image/png', body: PIXEL_PNG }));
-    await page.route(STREAM_URL_RE, () => {
-      // Keep the stream pending so the app remains in loading state.
-    });
+  test('loading sound plays without any sound network request', async ({ page }) => {
+    const c = ui(page);
+    await mockStreamsHang(page);
 
     await page.goto('/');
     await waitForSoundBlobs(page);
     const lateSoundRequests = await blockLateSoundRequests(page);
 
-    await page.locator('#playButton').click();
-    await expect(page.locator('#loadingMsg')).not.toHaveClass(/invisible/, { timeout: 3000 });
-    await expectSoundPlayingFromBlob(page, 'loadingNoise');
+    await c.playButton.click();
+    await expect(c.loadingMsg).toBeVisible({ timeout: 3000 });
+    await expectSoundPlaying(page, 'loadingNoise');
 
     expect(lateSoundRequests).toEqual([]);
   });
 
-  test('offline station change stops loading warmup when error sound starts', async ({ page }) => {
-    await page.route(/res\.cloudinary\.com/, (route) =>
-      route.fulfill({ status: 200, contentType: 'image/png', body: PIXEL_PNG }));
-
+  test('offline station change plays the error sound, not the loading one', async ({ page }) => {
+    const c = ui(page);
     await page.goto('/');
     await waitForSoundBlobs(page);
     await page.context().setOffline(true);
 
-    await page.locator('#nextButton').click();
-    await expect(page.locator('#errorMsg')).not.toHaveClass(/invisible/, { timeout: 3000 });
-    await expectSoundPlayingFromBlob(page, 'errorNoise');
+    await c.nextButton.click();
+    await expect(c.errorMsg).toBeVisible({ timeout: 3000 });
+    await expectSoundPlaying(page, 'errorNoise');
 
     const loadingPaused = await page.evaluate(() => document.getElementById('loadingNoise').paused);
     expect(loadingPaused).toBe(true);
   });
 
-  test('error sound plays offline from preloaded blob', async ({ page }) => {
-    await page.route(/res\.cloudinary\.com/, (route) =>
-      route.fulfill({ status: 200, contentType: 'image/png', body: PIXEL_PNG }));
+  test('error sound plays while offline, with no sound network request', async ({ page }) => {
+    const c = ui(page);
     await mockStreams(page);
 
     await page.goto('/');
-    await page.locator('#playButton').click();
-    await expect(page.locator('#pauseButton')).toBeVisible({ timeout: 8000 });
+    await c.playButton.click();
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
 
     await waitForSoundBlobs(page);
     const lateSoundRequests = await blockLateSoundRequests(page);
 
     await page.context().setOffline(true);
 
-    // nextButton → offline → error → errorSound.play() from blob
-    await page.locator('#nextButton').click();
-    await expect(page.locator('#errorMsg')).not.toHaveClass(/invisible/, { timeout: 3000 });
+    await c.nextButton.click();
+    await expect(c.errorMsg).toBeVisible({ timeout: 3000 });
 
-    await expectSoundPlayingFromBlob(page, 'errorNoise');
+    await expectSoundPlaying(page, 'errorNoise');
     expect(lateSoundRequests).toEqual([]);
   });
 
-  test('loading sound plays from preloaded blob', async ({ page }) => {
-    await page.route(/res\.cloudinary\.com/, (route) =>
-      route.fulfill({ status: 200, contentType: 'image/png', body: PIXEL_PNG }));
-
+  test('loading sound plays while the next station is still connecting', async ({ page }) => {
+    const c = ui(page);
     // Stream mock with a flag to simulate slow/stuck response
     let blockStream = false;
     await page.route(
@@ -641,8 +721,8 @@ test.describe('Offline — cached resources', () => {
     );
 
     await page.goto('/');
-    await page.locator('#playButton').click();
-    await expect(page.locator('#pauseButton')).toBeVisible({ timeout: 8000 });
+    await c.playButton.click();
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
 
     await waitForSoundBlobs(page);
     const lateSoundRequests = await blockLateSoundRequests(page);
@@ -650,25 +730,22 @@ test.describe('Offline — cached resources', () => {
     // Block stream so next station stays in loading state
     blockStream = true;
 
-    await page.locator('#nextButton').click();
-    await expect(page.locator('#loadingMsg')).not.toHaveClass(/invisible/, { timeout: 3000 });
+    await c.nextButton.click();
+    await expect(c.loadingMsg).toBeVisible({ timeout: 3000 });
 
-    await expectSoundPlayingFromBlob(page, 'loadingNoise');
+    await expectSoundPlaying(page, 'loadingNoise');
     expect(lateSoundRequests).toEqual([]);
   });
 
   test('sounds and error image work offline without prior play (SW pre-cache)', async ({ page }) => {
-    await page.route(/res\.cloudinary\.com/, (route) =>
-      route.fulfill({ status: 200, contentType: 'image/png', body: PIXEL_PNG }));
-
+    const c = ui(page);
     await page.goto('/');
 
-    // Wait for SW to activate and pre-cache sounds
+    // Synchronization only: wait for the SW to activate and pre-cache sounds
     await page.waitForFunction(() =>
       navigator.serviceWorker.ready.then(reg => reg.active !== null),
       { timeout: 10000 }
     );
-    // Give SW time to finish cache.addAll in install event
     await page.waitForFunction(async () => {
       const cache = await caches.open('radio-sounds-v1');
       const keys = await cache.keys();
@@ -678,35 +755,22 @@ test.describe('Offline — cached resources', () => {
     // Go offline WITHOUT ever pressing play
     await page.context().setOffline(true);
 
-    // Click next — should trigger error state with sound + image from cache
-    await page.locator('#nextButton').click();
-    await expect(page.locator('#errorMsg')).not.toHaveClass(/invisible/, { timeout: 3000 });
-
-    // Error image should render offline
-    await page.waitForFunction(() => {
-      const img = document.querySelector('#posterImage img');
-      return img.complete && img.naturalWidth > 0;
-    }, { timeout: 5000 });
-
-    // Error sound should play (from SW cache or blob)
-    await page.waitForTimeout(500);
-    const errorPlaying = await page.evaluate(() => {
-      const el = document.getElementById('errorNoise');
-      return !el.paused;
-    });
-    expect(errorPlaying).toBe(true);
+    // Click next — should show the error with sound + image, all from cache
+    await c.nextButton.click();
+    await expect(c.errorMsg).toBeVisible({ timeout: 3000 });
+    await expectPosterRendered(page);
+    await expectSoundPlaying(page, 'errorNoise');
 
     // Stop — should show idle image offline
-    await page.locator('#stopButton').click();
-    await expect(page.locator('#playButton')).toBeVisible();
-
-    await page.waitForFunction(() => {
-      const img = document.querySelector('#posterImage img');
-      return img.complete && img.naturalWidth > 0;
-    }, { timeout: 5000 });
+    await c.stopButton.click();
+    await expect(c.playButton).toBeVisible();
+    await expectPosterRendered(page);
   });
 });
 
+// Deliberate white-box exception: a stale-cache regression manifests as the
+// WRONG audio playing, which a headless test cannot hear. Inspecting the
+// cache contents is the only practical way to guard it.
 test.describe('Sound cache versioning', () => {
   test.use({ serviceWorkers: 'block' });
 

--- a/src/js/radioCore.js
+++ b/src/js/radioCore.js
@@ -10,7 +10,9 @@ import { createStateMachine } from './stateMachine.js';
 export const MAX_RETRIES = 1;
 export const LOADING_TIMEOUT_MS = 6000;
 export const RECOVERY_DELAY_MS = 10000;
-export const MAX_RECOVERY_ATTEMPTS = 30;
+export const RECOVERY_DELAY_MAX_MS = 60000;
+export const WATCHDOG_INTERVAL_MS = 2000;
+export const WATCHDOG_STALL_TICKS = 3; // ≈6s of frozen playback ⇒ stream is dead
 
 const STATE_FX = {
   idle:       { button: 'play',  loading: 'stop',  error: 'stop',  loadingMsg: false, errorMsg: false },
@@ -33,6 +35,7 @@ export function createRadioCore(deps) {
     playerSetSrc,
     playerLoad,
     playerIsPaused,
+    playerCurrentTime,
     loadingSound,
     errorSound,
     showButton,
@@ -42,11 +45,13 @@ export function createRadioCore(deps) {
     saveLastIndex,
     setTimeout: _setTimeout,
     clearTimeout: _clearTimeout,
+    setInterval: _setInterval,
+    clearInterval: _clearInterval,
     performanceNow,
     isOnline,
   } = deps;
 
-  const timers = { retry: null, loading: null, recovery: null };
+  const timers = { retry: null, loading: null, recovery: null, watchdog: null };
   let retryCount = 0;
   let recoveryCount = 0;
   let currentPlayId = 0;
@@ -61,6 +66,9 @@ export function createRadioCore(deps) {
     setLoadingMsg(fx.loadingMsg);
     setErrorMsg(fx.errorMsg);
     updateMediaSession(newState);
+    // The watchdog only makes sense while we're supposed to be playing
+    if (newState === 'playing') startWatchdog();
+    else stopWatchdog();
   });
 
   setState('idle');
@@ -239,14 +247,50 @@ export function createRadioCore(deps) {
     }
   }
 
-  // Schedule a silent recovery attempt after RECOVERY_DELAY_MS
+  // --- Playback watchdog ---
+  // Stream failures often don't fire any 'error'/'stalled' event — the audio
+  // just goes silent while currentTime stops advancing (classic with HLS or
+  // flaky wifi). The only reliable signal is playback progress itself: while
+  // state is 'playing', currentTime must keep moving.
+
+  let watchdogLastTime = null;
+  let watchdogStallTicks = 0;
+
+  function stopWatchdog() {
+    _clearInterval(timers.watchdog);
+    timers.watchdog = null;
+  }
+
+  function startWatchdog() {
+    stopWatchdog();
+    watchdogLastTime = null;
+    watchdogStallTicks = 0;
+    timers.watchdog = _setInterval(() => {
+      if (getState() !== 'playing') return;
+      const t = playerCurrentTime();
+      if (watchdogLastTime === null || t !== watchdogLastTime) {
+        watchdogLastTime = t;
+        watchdogStallTicks = 0;
+        return;
+      }
+      watchdogStallTicks++;
+      if (watchdogStallTicks >= WATCHDOG_STALL_TICKS) {
+        stopWatchdog();
+        handlePlayError(currentPlayId, getSelectedIndex(), new Error('Playback stalled'));
+      }
+    }, WATCHDOG_INTERVAL_MS);
+  }
+
+  // Schedule a silent recovery attempt with exponential backoff
+  // (10s → 20s → 40s → capped at RECOVERY_DELAY_MAX_MS), forever — a radio
+  // should never give up and strand the user in a dead error state.
   function scheduleRecovery() {
-    if (recoveryCount >= MAX_RECOVERY_ATTEMPTS) return;
     recoveryCount++;
+    const backoff = RECOVERY_DELAY_MS * 2 ** Math.min(recoveryCount - 1, 6);
     _clearTimeout(timers.recovery);
     timers.recovery = _setTimeout(() => {
       retryFromError();
-    }, RECOVERY_DELAY_MS);
+    }, Math.min(backoff, RECOVERY_DELAY_MAX_MS));
   }
 
   // Silent recovery: uses the state machine ('recovering' state).
@@ -255,9 +299,15 @@ export function createRadioCore(deps) {
     const s = getState();
     if (s !== 'error' && s !== 'recovering') return;
 
-    // No point trying without connectivity — wait for 'online' event
+    // Clearly offline (interface down) — re-check on a fixed cadence without
+    // escalating the backoff: nothing was attempted, and the 'online' event
+    // will trigger an immediate retry anyway. isOnline() can be a false
+    // positive (wifi without internet), so when it says true we always try.
     if (!isOnline()) {
-      scheduleRecovery();
+      _clearTimeout(timers.recovery);
+      timers.recovery = _setTimeout(() => {
+        retryFromError();
+      }, RECOVERY_DELAY_MS);
       return;
     }
 

--- a/src/js/radioCore.test.js
+++ b/src/js/radioCore.test.js
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createRadioCore, MAX_RECOVERY_ATTEMPTS, RECOVERY_DELAY_MS } from './radioCore.js';
+import {
+  createRadioCore,
+  RECOVERY_DELAY_MS,
+  RECOVERY_DELAY_MAX_MS,
+  WATCHDOG_INTERVAL_MS,
+  WATCHDOG_STALL_TICKS,
+} from './radioCore.js';
 
 // --- Helpers ---
 
@@ -19,6 +25,7 @@ function makeDeps(overrides = {}) {
     selectedIndex: 0,
     paused: true,
     now: 0,
+    currentTime: 0,
   };
 
   // By default playerPlay resolves (stream connects instantly)
@@ -38,6 +45,7 @@ function makeDeps(overrides = {}) {
     playerSetSrc: (url) => { calls.playerSetSrc.push(url); },
     playerLoad: () => { calls.playerLoad.push('load'); },
     playerIsPaused: () => calls.paused,
+    playerCurrentTime: () => calls.currentTime,
     loadingSound: {
       play: () => calls.loadingSound.push('play'),
       stop: () => calls.loadingSound.push('stop'),
@@ -59,7 +67,16 @@ function makeDeps(overrides = {}) {
     clearTimeout: vi.fn((id) => {
       deps._pendingTimers.delete(id);
     }),
+    setInterval: vi.fn((fn, ms) => {
+      const id = Math.random();
+      deps._pendingIntervals.set(id, { fn, ms });
+      return id;
+    }),
+    clearInterval: vi.fn((id) => {
+      deps._pendingIntervals.delete(id);
+    }),
     _pendingTimers: new Map(),
+    _pendingIntervals: new Map(),
     // test helpers
     _setPlayerPlayResult: (p) => { playerPlayResult = p; },
     performanceNow: () => calls.now,
@@ -83,6 +100,14 @@ function fireTimer(deps, delayMs) {
     }
   }
   return false;
+}
+
+function tickWatchdog(deps, times = 1) {
+  for (let i = 0; i < times; i++) {
+    for (const timer of deps._pendingIntervals.values()) {
+      if (timer.ms === WATCHDOG_INTERVAL_MS) timer.fn();
+    }
+  }
 }
 
 // =============================================
@@ -804,11 +829,11 @@ describe('restart after long pause', () => {
 });
 
 // =============================================
-// MAX RECOVERY ATTEMPTS
+// RECOVERY — exponential backoff, never gives up
 // =============================================
 
-describe('max recovery attempts', () => {
-  it('stops scheduling recovery after MAX_RECOVERY_ATTEMPTS', async () => {
+describe('recovery backoff', () => {
+  it('keeps scheduling recovery forever, with exponential backoff capped at RECOVERY_DELAY_MAX_MS', async () => {
     const { deps } = makeDeps();
     deps._setPlayerPlayResult(Promise.reject(new Error('fail')));
     const core = createRadioCore(deps);
@@ -820,18 +845,23 @@ describe('max recovery attempts', () => {
     await flushPromises(); // → error
     expect(core.getState()).toBe('error');
 
-    // Exhaust all recovery attempts
-    for (let i = 0; i < MAX_RECOVERY_ATTEMPTS; i++) {
-      fireTimer(deps, RECOVERY_DELAY_MS); // scheduleRecovery fires retryFromError
-      await flushPromises(); // recovery .catch → error + scheduleRecovery
+    // Each failed recovery doubles the delay, capped at the max
+    const expectedDelays = [
+      RECOVERY_DELAY_MS,      // 10s
+      RECOVERY_DELAY_MS * 2,  // 20s
+      RECOVERY_DELAY_MS * 4,  // 40s
+      RECOVERY_DELAY_MAX_MS,  // capped at 60s
+      RECOVERY_DELAY_MAX_MS,  // stays capped
+    ];
+    for (const delay of expectedDelays) {
+      expect([...deps._pendingTimers.values()].some(t => t.ms === delay)).toBe(true);
+      fireTimer(deps, delay); // retryFromError → recovering
+      await flushPromises();  // fails → error + reschedule
+      expect(core.getState()).toBe('error');
     }
 
-    expect(core.getState()).toBe('error');
-    expect(core._getRecoveryCount()).toBe(MAX_RECOVERY_ATTEMPTS);
-
-    // No more timers should be pending for recovery
-    const hasRecoveryTimer = [...deps._pendingTimers.values()].some(t => t.ms === RECOVERY_DELAY_MS);
-    expect(hasRecoveryTimer).toBe(false);
+    // Recovery never gives up — there is always a next attempt scheduled
+    expect([...deps._pendingTimers.values()].some(t => t.ms === RECOVERY_DELAY_MAX_MS)).toBe(true);
   });
 
   it('resets recovery count on successful playRadio', async () => {
@@ -884,17 +914,17 @@ describe('max recovery attempts', () => {
     await flushPromises();
     expect(core.getState()).toBe('error');
 
-    // Do a few failed recoveries
+    // Do a few failed recoveries (backoff: 10s, then 20s)
     fireTimer(deps, RECOVERY_DELAY_MS);
     await flushPromises();
-    fireTimer(deps, RECOVERY_DELAY_MS);
+    fireTimer(deps, RECOVERY_DELAY_MS * 2);
     await flushPromises();
     // count=3: initial scheduleRecovery(1) + two failed retryFromError re-schedules(2,3)
     expect(core._getRecoveryCount()).toBe(3);
 
     // Now make recovery succeed
     deps._setPlayerPlayResult(Promise.resolve());
-    fireTimer(deps, RECOVERY_DELAY_MS);
+    fireTimer(deps, RECOVERY_DELAY_MS * 4);
     await flushPromises();
 
     expect(core.getState()).toBe('playing');
@@ -920,7 +950,8 @@ describe('max recovery attempts', () => {
 
     expect(core.getState()).toBe('error');
     expect(calls.playerSetSrc.at(-1)).toBe('');
-    expect([...deps._pendingTimers.values()].some(t => t.ms === RECOVERY_DELAY_MS)).toBe(true);
+    // Second failed attempt → backoff doubles to 20s
+    expect([...deps._pendingTimers.values()].some(t => t.ms === RECOVERY_DELAY_MS * 2)).toBe(true);
   });
 
   it('offline recovery reschedules without attempting stream', async () => {
@@ -977,9 +1008,9 @@ describe('max recovery attempts', () => {
     expect(core._getRecoveryCount()).toBe(0);
   });
 
-  it('offline recovery loops are also bounded by MAX_RECOVERY_ATTEMPTS', async () => {
+  it('offline recovery keeps re-checking indefinitely (no dead end)', async () => {
     let online = true;
-    const { deps } = makeDeps({ isOnline: () => online });
+    const { deps, calls } = makeDeps({ isOnline: () => online });
     deps._setPlayerPlayResult(Promise.reject(new Error('fail')));
     const core = createRadioCore(deps);
 
@@ -990,18 +1021,105 @@ describe('max recovery attempts', () => {
     await flushPromises();
     expect(core.getState()).toBe('error');
 
-    // Go offline and exhaust all recovery attempts
+    // Stay offline for a long time — far beyond the old 30-attempt cap
     online = false;
-    for (let i = 0; i < MAX_RECOVERY_ATTEMPTS; i++) {
+    const playsBefore = calls.playerPlay.length;
+    for (let i = 0; i < 100; i++) {
       fireTimer(deps, RECOVERY_DELAY_MS);
       await flushPromises();
     }
 
+    // Still waiting patiently: no stream attempts, but always a next check
     expect(core.getState()).toBe('error');
-    expect(core._getRecoveryCount()).toBe(MAX_RECOVERY_ATTEMPTS);
+    expect(calls.playerPlay.length).toBe(playsBefore);
+    expect([...deps._pendingTimers.values()].some(t => t.ms === RECOVERY_DELAY_MS)).toBe(true);
 
-    // No more recovery timers — loop is capped even while offline
-    const hasRecoveryTimer = [...deps._pendingTimers.values()].some(t => t.ms === RECOVERY_DELAY_MS);
-    expect(hasRecoveryTimer).toBe(false);
+    // Net comes back — the very next check recovers playback on its own
+    online = true;
+    deps._setPlayerPlayResult(Promise.resolve());
+    fireTimer(deps, RECOVERY_DELAY_MS);
+    await flushPromises();
+    expect(core.getState()).toBe('playing');
+  });
+});
+
+// =============================================
+// PLAYBACK WATCHDOG (silent stalls — HLS, flaky wifi)
+// =============================================
+
+describe('playback watchdog', () => {
+  it('does nothing while playback progresses', async () => {
+    const { deps, calls } = makeDeps();
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    await flushPromises();
+    expect(core.getState()).toBe('playing');
+
+    for (let i = 0; i < 10; i++) {
+      calls.currentTime += 2;
+      tickWatchdog(deps);
+    }
+    expect(core.getState()).toBe('playing');
+  });
+
+  it('restarts the stream when playback time freezes', async () => {
+    const { deps, calls } = makeDeps();
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    await flushPromises();
+    expect(core.getState()).toBe('playing');
+
+    // Some healthy progress first
+    calls.currentTime = 5;
+    tickWatchdog(deps);
+
+    // currentTime freezes: after WATCHDOG_STALL_TICKS frozen ticks → retry
+    tickWatchdog(deps, WATCHDOG_STALL_TICKS);
+    expect(core.getState()).toBe('retrying');
+
+    // The normal retry cycle then recovers playback
+    fireTimer(deps, 3000);
+    await flushPromises();
+    expect(core.getState()).toBe('playing');
+  });
+
+  it('a moment of progress resets the stall countdown', async () => {
+    const { deps, calls } = makeDeps();
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    await flushPromises();
+
+    calls.currentTime = 5;
+    tickWatchdog(deps);
+    tickWatchdog(deps, WATCHDOG_STALL_TICKS - 1); // almost stalled…
+    calls.currentTime = 6;                        // …but it moves again
+    tickWatchdog(deps);
+    tickWatchdog(deps, WATCHDOG_STALL_TICKS - 1); // frozen again, not enough
+    expect(core.getState()).toBe('playing');
+
+    tickWatchdog(deps); // one more frozen tick crosses the threshold
+    expect(core.getState()).toBe('retrying');
+  });
+
+  it('stops watching when paused or stopped', async () => {
+    const { deps } = makeDeps();
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    await flushPromises();
+    expect(deps._pendingIntervals.size).toBe(1);
+
+    core.onPlayerPause();
+    expect(core.getState()).toBe('paused');
+    expect(deps._pendingIntervals.size).toBe(0);
+
+    core.onPlayerPlay();
+    expect(deps._pendingIntervals.size).toBe(1);
+
+    core.stopRadio();
+    expect(deps._pendingIntervals.size).toBe(0);
   });
 });

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -379,6 +379,7 @@ core = createRadioCore({
   playerSetSrc:     (url) => { player.src = url; },
   playerLoad:       () => player.load(),
   playerIsPaused:   () => player.paused,
+  playerCurrentTime: () => player.currentTime,
   loadingSound:     loadingNoiseInstance,
   errorSound:       errorNoiseInstance,
   showButton,
@@ -388,6 +389,8 @@ core = createRadioCore({
   saveLastIndex:    (i) => localStorage.setItem('lastRadioIndex', i),
   setTimeout,
   clearTimeout,
+  setInterval,
+  clearInterval,
   performanceNow:   () => performance.now(),
   isOnline:          () => navigator.onLine,
 });
@@ -455,22 +458,10 @@ player.addEventListener('pause', () => {
 });
 
 // Stream failure during playback (lost WiFi, server died, etc.)
+// Silent failures (no 'error' event, audio just stops — common on HLS and
+// flaky wifi) are caught by the core's playback-progress watchdog instead of
+// the unreliable 'stalled' event.
 player.addEventListener('error', () => core.onPlayerError());
-
-function isCurrentStreamHls() {
-  return /\.m3u8(?:[?#].*)?$/.test(player.currentSrc || player.src);
-}
-
-player.addEventListener('stalled', () => {
-  if (isCurrentStreamHls()) return;
-
-  const playIdAtStall = core._getPlayId();
-  const stalledTimeout = setTimeout(() => {
-    // Only treat as error if we're still on the same stream
-    if (core._getPlayId() === playIdAtStall && core.getState() === 'playing') core.onPlayerError();
-  }, 5000);
-  player.addEventListener('playing', () => clearTimeout(stalledTimeout), { once: true });
-});
 
 // Auto-recovery when network comes back
 window.addEventListener('online', () => core.retryFromError());


### PR DESCRIPTION
## Problema

Pe net intermitent aplicația rămânea blocată într-o „stare ciudată": fie afișa `playing` cu liniște totală (stream mort fără niciun eveniment media), fie rămânea în `error` pentru totdeauna după ce netul revenea.

## Cauzele găsite

1. **Dead-end în recovery**: `MAX_RECOVERY_ATTEMPTS = 30` × 10s — după ~5 minute de net căzut, recovery-ul se oprea definitiv.
2. **`navigator.onLine` minte pe net intermitent**: WiFi conectat fără internet ⇒ `onLine` rămâne `true`, evenimentul `online` nu se emite niciodată, deci nimic nu mai scotea aplicația din `error`.
3. **Stall silențios invizibil**: la căderi de net în timpul redării, `<audio>` de multe ori nu emite `error`; handlerul de `stalled` era nesigur și excludea explicit HLS (FIP), deci înghețurile pe HLS nu erau detectate deloc.

## Soluția

- **Watchdog pe progresul redării** (`radioCore.js`): cât timp starea e `playing`, `currentTime` trebuie să avanseze; ~6s de îngheț ⇒ ciclul normal de retry/recovery. Funcționează identic pe HLS și MP3, fără falsuri pozitive. Handlerul de `stalled` a fost eliminat complet (se emite rutinier între segmentele HLS și producea flash-uri false de „Se încarcă...").
- **Recovery fără dead-end**: backoff exponențial 10s → 20s → 40s → plafon 60s, la infinit.
- **Offline explicit**: când `onLine === false`, re-verificare fixă la 10s fără atingerea rețelei; evenimentul `online` declanșează retry instant. Când `onLine === true`, se încearcă mereu — încercarea stream-ului e cea mai onestă probă de conectivitate.

## E2E rescris la nivel de utilizator

Toate interacțiunile prin roluri accesibile (helper `ui()`), asertări pe text vizibil / titlul paginii / starea butoanelor — fără id-uri, clase CSS sau stare internă. Teste noi: `stalled` tranzitoriu pe HLS nu întrerupe redarea; scenariul complet cădere-de-net → îngheț silențios → watchdog → reconectare automată (pe HLS real, redat nativ de Chromium).

## Known issue documentat (README)

Playerul HLS nativ din Chromium, când netul moare cu un `.m3u8` atașat, intră într-o buclă internă de ~4.700 req/s fără să emită `error` (măsurat: 239k request-uri/60s pe un `<audio>` gol, fără logică de aplicație). Aplicația îl conține în scenariul offline (detașează `src` în error; măsurat: 2 request-uri în 45s). Rămâne o fereastră rară la reconectare — decizie: fără workaround deocamdată, opțiuni documentate în README.

## Teste

- 53 unit (Vitest) ✅ — suite noi: playback watchdog, recovery backoff
- 35 e2e (Playwright) ✅ — inclusiv scenariul drop-and-recover pe HLS (12s, exercită lanțul real buffer → watchdog → retry → recovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)