### PR TITLE
Fix: sunet permanent cand pica reteaua in timpul redarii

### DIFF
--- a/e2e/radio.spec.js
+++ b/e2e/radio.spec.js
@@ -820,3 +820,68 @@ test.describe('Sound cache versioning', () => {
     });
   });
 });
+
+// The user's core promise: once they pressed play, the app must never sit in
+// silence. If the network dies mid-playback the OS pauses the dead stream
+// element — the app must treat that as a failure (audible loading → error),
+// NOT as the user pressing pause.
+test.describe('Offline mid-playback — always audible', () => {
+
+  test('going offline while playing keeps a sound on and recovers by itself', async ({ page }) => {
+    test.setTimeout(60_000);
+    const c = ui(page);
+
+    let connectionDown = false;
+    await page.route(STREAM_URL_RE, async (route) => {
+      if (connectionDown) {
+        await route.abort('internetdisconnected');
+        return;
+      }
+      await route.fulfill({ status: 200, contentType: 'audio/mpeg', path: 'src/public/sounds/test-tone.mp3' });
+    });
+
+    await page.goto('/');
+    await waitForSoundBlobs(page);
+
+    await c.playButton.click();
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
+
+    // The connection drops, and — like on a phone — the OS pauses the dead
+    // stream element. (Calling pause() on the element IS the OS behaviour;
+    // same environment-simulation approach as the 'stalled' test above.)
+    connectionDown = true;
+    await page.context().setOffline(true);
+    await page.locator('#player').evaluate((el) => el.pause());
+
+    // NOT the paused UI: the app announces the problem (audible retry runs
+    // first, then the offline retry lands in error) instead of going mute
+    await expect(c.errorMsg).toBeVisible({ timeout: 10000 });
+    await expect(c.playButton).toBeHidden();
+    await expectSoundPlaying(page, 'errorNoise');
+
+    // The network comes back — the radio recovers with no click
+    connectionDown = false;
+    await page.context().setOffline(false);
+    await expect(c.pauseButton).toBeVisible({ timeout: 45000 });
+  });
+
+  test('pausing on purpose stays paused — even if the app is offline', async ({ page }) => {
+    test.setTimeout(60_000);
+    const c = ui(page);
+    await mockStreams(page);
+
+    await page.goto('/');
+    await c.playButton.click();
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
+
+    await c.pauseButton.click();
+    await page.context().setOffline(true);
+
+    // A deliberate pause is respected: play control shows, no error, no sounds
+    await expect(c.playButton).toBeVisible();
+    await page.waitForTimeout(4000); // enough for any misfired retry to surface
+    await expect(c.playButton).toBeVisible();
+    await expect(c.errorMsg).toBeHidden();
+    await expect(c.loadingMsg).toBeHidden();
+  });
+});

--- a/plan.md
+++ b/plan.md
@@ -101,6 +101,36 @@ Verificari (efectuate):
 - Ramas pentru PR: deploy preview pe Vercel (routes + headers) si smoke
   MediaSession pe device real.
 
+## Interludiu (inainte de Faza 2): fix "always audible" la offline [gata]
+
+Bug raportat: pe mobil, cand pica reteaua in timpul redarii, sunetul de
+loading/eroare uneori nu se aude, iar UI-ul arata "paused" desi userul nu a
+dat pauza. Cauze gasite si fixate (branch `fix/always-audible-offline`):
+
+1. Pauza nativa data de OS la moartea stream-ului era tratata ca pauza de la
+   user -> starea 'paused' oprea watchdog-ul si nu programa nicio recuperare.
+   Fix: pauseRadio() marcheaza intentia userului (USER_PAUSE_INTENT_MS);
+   un pause neasteptat + offline intra pe pipeline-ul retry/error cu sunete.
+   Pause neasteptat + online ramane 'paused' (casti scoase, telefon, alta
+   aplicatie) — gap cunoscut: wifi fara internet + pause nativ.
+2. Sunetele porneau o singura data, fara retry la reject (tipic in background).
+   Fix: sound supervisor — interval (SOUND_SUPERVISOR_INTERVAL_MS) care
+   re-aserteaza sunetul cerut de stare via ensure() cat timp starea e
+   loading/retrying/error/recovering.
+3. 'retrying' avea loading:'keep' -> venind din watchdog stall, 3s de tacere.
+   Fix: loading:'play'.
+4. Cerinta noua: sunetul de eroare audibil minim 1 minut (ERROR_SOUND_AUDIBLE_MS),
+   apoi mute() — elementul continua loop-ul MUT ca sa tina sesiunea media si
+   timerele vii in background, iar recovery-ul silentios continua la nesfarsit.
+   De validat pe iOS real daca loop-ul mut chiar previne suspendarea.
+
+Teste: 11 unit tests noi (64 total), 2 e2e noi (37 total) — cele 35 e2e vechi
+neatinse si verzi. Comportamentul e specificat executabil in describe-ul e2e
+'Offline mid-playback — always audible'.
+
+Nota pentru Faza 4 (XState): aceste comportamente (intentie pauza, supervisor,
+cap eroare) se porteaza ca events/guards/actori — testele raman dovada.
+
 ## Faza 2: TypeScript
 
 Obiectiv: type safety pe contractul core <-> DOM, fara nicio schimbare de logica.

--- a/src/js/radioCore.js
+++ b/src/js/radioCore.js
@@ -13,13 +13,18 @@ export const RECOVERY_DELAY_MS = 10000;
 export const RECOVERY_DELAY_MAX_MS = 60000;
 export const WATCHDOG_INTERVAL_MS = 2000;
 export const WATCHDOG_STALL_TICKS = 3; // ≈6s of frozen playback ⇒ stream is dead
+export const SOUND_SUPERVISOR_INTERVAL_MS = 2500;
+export const ERROR_SOUND_AUDIBLE_MS = 60000; // audible error for at least a minute, then muted
+export const USER_PAUSE_INTENT_MS = 2000; // how long a pauseRadio() call explains a native 'pause'
 
 const STATE_FX = {
   idle:       { button: 'play',  loading: 'stop',  error: 'stop',  loadingMsg: false, errorMsg: false },
   loading:    { button: 'stop',  loading: 'play',  error: 'stop',  loadingMsg: true,  errorMsg: false },
   playing:    { button: 'pause', loading: 'stop',  error: 'stop',  loadingMsg: false, errorMsg: false },
   paused:     { button: 'play',  loading: 'stop',  error: 'stop',  loadingMsg: false, errorMsg: false },
-  retrying:   { button: 'stop',  loading: 'keep',  error: 'stop',  loadingMsg: false, errorMsg: false },
+  // 'play' (not 'keep'): a retry can also start from a watchdog stall while
+  // playing, where no sound is active — the user must never sit in silence.
+  retrying:   { button: 'stop',  loading: 'play',  error: 'stop',  loadingMsg: false, errorMsg: false },
   error:      { button: 'stop',  loading: 'stop',  error: 'play',  loadingMsg: false, errorMsg: true  },
   recovering: { button: 'stop',  loading: 'stop',  error: 'keep',  loadingMsg: false, errorMsg: true  },
 };
@@ -51,11 +56,13 @@ export function createRadioCore(deps) {
     isOnline,
   } = deps;
 
-  const timers = { retry: null, loading: null, recovery: null, watchdog: null };
+  const timers = { retry: null, loading: null, recovery: null, watchdog: null, soundSupervisor: null };
   let retryCount = 0;
   let recoveryCount = 0;
   let currentPlayId = 0;
   let lastPauseTime = null;
+  let userPauseIntentAt = null; // performanceNow() of the last pauseRadio() call
+  let errorSoundStartedAt = null; // when the current uninterrupted error cycle began
 
   // --- State machine (no radio knowledge) ---
 
@@ -69,6 +76,20 @@ export function createRadioCore(deps) {
     // The watchdog only makes sense while we're supposed to be playing
     if (newState === 'playing') startWatchdog();
     else stopWatchdog();
+    // Track how long the user has been listening to the error sound —
+    // one uninterrupted error/recovering stretch counts as one cycle.
+    if (newState === 'error' || newState === 'recovering') {
+      if (errorSoundStartedAt === null) errorSoundStartedAt = performanceNow();
+    } else {
+      errorSoundStartedAt = null;
+    }
+    // While a feedback sound is supposed to be audible, supervise it:
+    // background restrictions can reject or pause <audio> playback silently.
+    if (newState === 'loading' || newState === 'retrying' || newState === 'error' || newState === 'recovering') {
+      startSoundSupervisor();
+    } else {
+      stopSoundSupervisor();
+    }
   });
 
   setState('idle');
@@ -167,6 +188,9 @@ export function createRadioCore(deps) {
   }
 
   function pauseRadio() {
+    // Remember that this pause was asked for by the user, so the native
+    // 'pause' event it triggers isn't mistaken for a dying stream.
+    userPauseIntentAt = performanceNow();
     playerPause();
   }
 
@@ -206,7 +230,7 @@ export function createRadioCore(deps) {
         playRadio(getSelectedIndex());
       }
     } else {
-      playerPause();
+      pauseRadio();
     }
   }
 
@@ -232,10 +256,26 @@ export function createRadioCore(deps) {
 
   // Called from native player 'pause' event
   function onPlayerPause() {
-    if (getState() === 'playing') {
-      setState('paused');
-      lastPauseTime = performanceNow();
+    if (getState() !== 'playing') return;
+
+    const userAskedForIt =
+      userPauseIntentAt !== null &&
+      performanceNow() - userPauseIntentAt <= USER_PAUSE_INTENT_MS;
+    userPauseIntentAt = null;
+
+    // A 'pause' nobody asked for while the network is down is the OS killing
+    // a dead stream, not the user — never leave them in silent 'paused':
+    // go through the retry/error pipeline so a feedback sound keeps playing.
+    if (!userAskedForIt && !isOnline()) {
+      lastPauseTime = null;
+      handlePlayError(currentPlayId, getSelectedIndex(), new Error('Network pause'));
+      return;
     }
+
+    // User pause, or an online interruption (headphones unplugged, phone
+    // call, another app taking audio) — those should stay paused.
+    setState('paused');
+    lastPauseTime = performanceNow();
   }
 
   // Called from native player 'error' event (e.g. stream dies mid-playback)
@@ -279,6 +319,37 @@ export function createRadioCore(deps) {
         handlePlayError(currentPlayId, getSelectedIndex(), new Error('Playback stalled'));
       }
     }, WATCHDOG_INTERVAL_MS);
+  }
+
+  // --- Sound supervisor ---
+  // "As long as the user pressed play, something must be audible." Feedback
+  // sounds can silently fail to start (autoplay/background restrictions) or
+  // get paused by the OS. While a state demands a sound, re-assert it every
+  // tick; after ERROR_SOUND_AUDIBLE_MS of uninterrupted error, mute the error
+  // loop (it keeps looping silently so background timers/session stay alive
+  // and silent recovery can keep trying forever).
+
+  function stopSoundSupervisor() {
+    _clearInterval(timers.soundSupervisor);
+    timers.soundSupervisor = null;
+  }
+
+  function superviseSounds() {
+    const s = getState();
+    if (s === 'loading' || s === 'retrying') {
+      loadingSound.ensure();
+    } else if (s === 'error' || s === 'recovering') {
+      if (errorSoundStartedAt !== null && performanceNow() - errorSoundStartedAt >= ERROR_SOUND_AUDIBLE_MS) {
+        errorSound.mute();
+      } else {
+        errorSound.ensure();
+      }
+    }
+  }
+
+  function startSoundSupervisor() {
+    if (timers.soundSupervisor !== null) return;
+    timers.soundSupervisor = _setInterval(superviseSounds, SOUND_SUPERVISOR_INTERVAL_MS);
   }
 
   // Schedule a silent recovery attempt with exponential backoff

--- a/src/js/radioCore.test.js
+++ b/src/js/radioCore.test.js
@@ -5,6 +5,9 @@ import {
   RECOVERY_DELAY_MAX_MS,
   WATCHDOG_INTERVAL_MS,
   WATCHDOG_STALL_TICKS,
+  SOUND_SUPERVISOR_INTERVAL_MS,
+  ERROR_SOUND_AUDIBLE_MS,
+  USER_PAUSE_INTENT_MS,
 } from './radioCore.js';
 
 // --- Helpers ---
@@ -49,10 +52,14 @@ function makeDeps(overrides = {}) {
     loadingSound: {
       play: () => calls.loadingSound.push('play'),
       stop: () => calls.loadingSound.push('stop'),
+      ensure: () => calls.loadingSound.push('ensure'),
+      mute: () => calls.loadingSound.push('mute'),
     },
     errorSound: {
       play: () => calls.errorSound.push('play'),
       stop: () => calls.errorSound.push('stop'),
+      ensure: () => calls.errorSound.push('ensure'),
+      mute: () => calls.errorSound.push('mute'),
     },
     showButton: (which) => calls.showButton.push(which),
     setLoadingMsg: (v) => calls.loadingMsg.push(v),
@@ -598,12 +605,9 @@ describe('retrying keeps loading sound', () => {
 
     expect(core.getState()).toBe('retrying');
 
-    // Find the loading sound calls after setState('retrying')
-    // 'retrying' has loading: 'keep' — so no stop should happen for retrying specifically
-    // The last loading action from setState('loading') was 'play'
-    // setState('retrying') should NOT add 'stop'
+    // 'retrying' asserts the loading sound itself (loading: 'play') so a retry
+    // reached from a watchdog stall is audible too — never stopped, never silent.
     const loadingAfterRetry = calls.loadingSound.slice(-1)[0];
-    // Last action should still be 'play' (from the loading state, not stopped by retrying)
     expect(loadingAfterRetry).toBe('play');
   });
 });
@@ -1121,5 +1125,196 @@ describe('playback watchdog', () => {
 
     core.stopRadio();
     expect(deps._pendingIntervals.size).toBe(0);
+  });
+});
+
+// =============================================
+// ALWAYS AUDIBLE — system pause vs user pause
+// (the network dying must never leave the app in silent 'paused')
+// =============================================
+
+function tickSupervisor(deps, times = 1) {
+  for (let i = 0; i < times; i++) {
+    for (const timer of deps._pendingIntervals.values()) {
+      if (timer.ms === SOUND_SUPERVISOR_INTERVAL_MS) timer.fn();
+    }
+  }
+}
+
+describe('system pause vs user pause', () => {
+  it('a pause the user asked for stays paused, even offline', async () => {
+    let online = true;
+    const { deps, calls } = makeDeps({ isOnline: () => online });
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    await flushPromises();
+    expect(core.getState()).toBe('playing');
+
+    core.pauseRadio();       // user intent…
+    online = false;          // …even if the network dies at the same moment
+    core.onPlayerPause();    // native event triggered by our own pause()
+
+    expect(core.getState()).toBe('paused');
+  });
+
+  it('an unexpected native pause while offline goes to retrying with the loading sound', async () => {
+    let online = true;
+    const { deps, calls } = makeDeps({ isOnline: () => online });
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    await flushPromises();
+
+    online = false;
+    core.onPlayerPause();    // OS killed the dead stream — nobody pressed pause
+
+    expect(core.getState()).toBe('retrying');
+    expect(calls.loadingSound.at(-1)).toBe('play');
+  });
+
+  it('the offline retry lands in error with the error sound and keeps recovering', async () => {
+    let online = true;
+    const { deps, calls } = makeDeps({ isOnline: () => online });
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    await flushPromises();
+
+    online = false;
+    core.onPlayerPause();
+    expect(core.getState()).toBe('retrying');
+
+    fireTimer(deps, 3000);   // the scheduled retry runs while still offline
+    expect(core.getState()).toBe('error');
+    expect(calls.errorSound.at(-1)).toBe('play');
+    expect(calls.errorMsg.at(-1)).toBe(true);
+
+    // Silent recovery is scheduled — the radio never gives up
+    fireTimer(deps, RECOVERY_DELAY_MS);
+    expect(core.getState()).toBe('error'); // still offline: fixed-cadence recheck
+    expect([...deps._pendingTimers.values()].some(t => t.ms === RECOVERY_DELAY_MS)).toBe(true);
+  });
+
+  it('an unexpected native pause while online still pauses (interruption, unplugged headphones)', async () => {
+    const { deps } = makeDeps();
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    await flushPromises();
+
+    core.onPlayerPause();    // no user intent, but the network is fine
+
+    expect(core.getState()).toBe('paused');
+  });
+
+  it('user pause intent expires after USER_PAUSE_INTENT_MS', async () => {
+    let online = true;
+    const { deps, calls } = makeDeps({ isOnline: () => online });
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    await flushPromises();
+
+    core.pauseRadio();
+    calls.now += USER_PAUSE_INTENT_MS + 1000; // the native pause arrives much later
+    online = false;
+    core.onPlayerPause();
+
+    expect(core.getState()).toBe('retrying'); // stale intent no longer explains it
+  });
+});
+
+// =============================================
+// SOUND SUPERVISOR — something must always be audible
+// =============================================
+
+describe('sound supervisor', () => {
+  it('re-asserts the loading sound while loading', async () => {
+    const { deps, calls } = makeDeps();
+    deps._setPlayerPlayResult(new Promise(() => {})); // stream never connects
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    expect(core.getState()).toBe('loading');
+
+    tickSupervisor(deps);
+    expect(calls.loadingSound.at(-1)).toBe('ensure');
+  });
+
+  it('re-asserts the error sound while in error', async () => {
+    const { deps, calls } = makeDeps({ isOnline: () => false });
+    const core = createRadioCore(deps);
+
+    core.playRadio(0); // offline → straight to error
+    expect(core.getState()).toBe('error');
+
+    tickSupervisor(deps);
+    expect(calls.errorSound.at(-1)).toBe('ensure');
+  });
+
+  it('mutes the error sound after ERROR_SOUND_AUDIBLE_MS but recovery continues', async () => {
+    const { deps, calls } = makeDeps({ isOnline: () => false });
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    expect(core.getState()).toBe('error');
+
+    tickSupervisor(deps);
+    expect(calls.errorSound.at(-1)).toBe('ensure'); // audible within the first minute
+
+    calls.now += ERROR_SOUND_AUDIBLE_MS;
+    tickSupervisor(deps);
+    expect(calls.errorSound.at(-1)).toBe('mute');   // silent afterwards…
+
+    // …while the silent recovery timer is still armed
+    expect([...deps._pendingTimers.values()].some(t => t.ms === RECOVERY_DELAY_MS)).toBe(true);
+  });
+
+  it('a new error cycle is audible again from the start', async () => {
+    let online = false;
+    const { deps, calls } = makeDeps({ isOnline: () => online });
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    calls.now += ERROR_SOUND_AUDIBLE_MS;
+    tickSupervisor(deps);
+    expect(calls.errorSound.at(-1)).toBe('mute');
+
+    core.stopRadio();                 // cycle ends (sound stopped + unmuted)
+    expect(calls.errorSound.at(-1)).toBe('stop');
+
+    core.playRadio(0);                // user tries again, still offline
+    expect(core.getState()).toBe('error');
+    tickSupervisor(deps);
+    expect(calls.errorSound.at(-1)).toBe('ensure'); // fresh cycle: audible again
+  });
+
+  it('recovering keeps the error-cycle clock running (no audible reset mid-cycle)', async () => {
+    const { deps, calls } = makeDeps({ isOnline: () => false });
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    expect(core.getState()).toBe('error');
+
+    calls.now += ERROR_SOUND_AUDIBLE_MS / 2;
+    fireTimer(deps, RECOVERY_DELAY_MS);      // offline recheck: error → (recovering skipped) error
+    calls.now += ERROR_SOUND_AUDIBLE_MS / 2;
+    tickSupervisor(deps);
+    expect(calls.errorSound.at(-1)).toBe('mute'); // one uninterrupted cycle: 60s total
+  });
+
+  it('the supervisor stops outside sound states', async () => {
+    const { deps } = makeDeps({ isOnline: () => false });
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    expect(core.getState()).toBe('error');
+    const supervisorCount = () =>
+      [...deps._pendingIntervals.values()].filter(t => t.ms === SOUND_SUPERVISOR_INTERVAL_MS).length;
+    expect(supervisorCount()).toBe(1);
+
+    core.stopRadio();
+    expect(supervisorCount()).toBe(0);
   });
 });

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -121,6 +121,7 @@ async function getSoundResponse(src) {
 function audioInstance(htmlElement) {
   let initialSrc = htmlElement.querySelector('source').src;
   let isPlaying = false;
+  let isMuted = false;
   let blobUrl = null;
   let playGeneration = 0;
   let preloadPromise = null;
@@ -152,6 +153,7 @@ function audioInstance(htmlElement) {
   const startPlayback = (gen) => {
     if (gen !== playGeneration || !isPlaying) return;
     htmlElement.volume = 1;
+    htmlElement.muted = isMuted;
     htmlElement.src = blobUrl || initialSrc;
     htmlElement.currentTime = 0;
     htmlElement.play().catch((error) => {
@@ -161,23 +163,51 @@ function audioInstance(htmlElement) {
     });
   };
 
-  return {
-    play() {
-      if (!isPlaying) {
-        const gen = ++playGeneration;
-        isPlaying = true;
-        if (blobUrl) {
-          startPlayback(gen);
-          return;
-        }
-        preloadBlob().then(() => startPlayback(gen));
+  const play = () => {
+    if (!isPlaying) {
+      isMuted = false;
+      htmlElement.muted = false;
+      const gen = ++playGeneration;
+      isPlaying = true;
+      if (blobUrl) {
+        startPlayback(gen);
+        return;
       }
-    },
+      preloadBlob().then(() => startPlayback(gen));
+    }
+  };
+
+  return {
+    play,
     stop() {
       playGeneration++;
       htmlElement.pause();
       htmlElement.src = '';
       isPlaying = false;
+      isMuted = false;
+      htmlElement.muted = false;
+    },
+    // Self-healing: called periodically by the core's sound supervisor while
+    // this sound is supposed to be audible. Restarts playback if a play()
+    // was rejected (background/autoplay policy) or the OS paused the element.
+    ensure() {
+      if (!isPlaying) {
+        play();
+        return;
+      }
+      if (htmlElement.paused) {
+        const gen = playGeneration;
+        htmlElement.play().catch((error) => {
+          if (gen !== playGeneration) return;
+          if (error.name !== 'AbortError') isPlaying = false; // retried next tick
+        });
+      }
+    },
+    // Keeps looping, but silently — playback continuing is what keeps the
+    // media session and background timers alive during long error stretches.
+    mute() {
+      isMuted = true;
+      htmlElement.muted = true;
     },
     warmUp() {
       if (isPlaying) return;


### PR DESCRIPTION
> Stacked pe #35 (base: `migrate-vite-ts-xstate`) — se face merge după #35.

## Bug-ul raportat

Pe mobil, când pică rețeaua în timpul redării: sunetul de loading/eroare uneori nu se aude (mai ales pe lock screen), iar UI-ul arată "paused" deși userul nu a dat pauză. Promisiunea produsului: **cât timp userul a dat play, ceva trebuie să se audă** — stream, loading sau eroare.

## Cauze găsite (3 defecte care se combină)

1. **Pauza nativă de la OS ≠ pauza userului** — când moare stream-ul, OS-ul dă `pause` pe elementul audio; `onPlayerPause()` o trata ca pauză de la user → starea `paused` oprea watchdog-ul și nu programa nicio recuperare. Tăcere permanentă.
2. **Sunetele porneau o singură dată, fără retry** — un `play()` respins (tipic în background) era doar logat; nimeni nu reîncerca.
3. **Gol de tăcere în `retrying`** — venind din watchdog stall, sunetul de loading nu era pornit (`keep`), deci 3s de liniște.

## Fix

- `pauseRadio()` marchează **intenția userului** (`USER_PAUSE_INTENT_MS`=2s); un pause neașteptat + offline intră pe pipeline-ul retry/eroare (cu sunete), nu în `paused`. Pause neașteptat + online rămâne pauză (căști scoase, telefon, altă aplicație).
- **Supervizor de sunet**: cât timp starea cere un sunet (loading/retrying/error/recovering), un interval de 2.5s re-asertează sunetul (`ensure()`) — repornește playback-ul respins sau oprit de OS.
- `retrying` pornește sunetul de loading (`play` în loc de `keep`).
- **Eroarea rămâne audibilă minim 1 minut** (`ERROR_SOUND_AUDIBLE_MS`), apoi trece pe **mute dar loop-ul continuă** — elementul audio activ ține sesiunea media și timerele vii în background, iar recuperarea silențioasă continuă la nesfârșit. La reconectare, radioul revine singur.

## Teste

- ✅ **11 unit tests noi** (64 total): user pause vs system pause (inclusiv expirarea intenției), supervizor, cap 60s + resetarea lui pe ciclu nou
- ✅ **2 e2e noi** (37 total): `Offline mid-playback — always audible` — specificația executabilă a comportamentului
- ✅ Cele **35 e2e existente neatinse și verzi**

## Limitări cunoscute

- Pause nativ + wifi-fără-internet (`navigator.onLine` încă `true`): rămâne pauză — indistinguibil de o întrerupere legitimă (apel, căști). Watchdog-ul acoperă cazul cât starea e încă `playing`.
- Eficacitatea loop-ului mut pentru menținerea sesiunii în background pe iOS trebuie validată pe device real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)