### PR TITLE
Handoff real între sunete: cel vechi cântă până când cel nou chiar se aude

### DIFF
--- a/e2e/radio.spec.js
+++ b/e2e/radio.spec.js
@@ -887,3 +887,69 @@ test.describe('Offline mid-playback — always audible', () => {
     await expect(c.loadingMsg).toBeHidden();
   });
 });
+
+// Deliberate white-box exception (same rationale as the cache-versioning
+// describe): the iOS behavior this guards — backgrounded Safari denying any
+// FRESH play() start while allowing an already-playing element to swap its
+// source and continue — cannot be reproduced in headless Chromium. We
+// simulate the denial by patching the error element's play() to reject the
+// way iOS does, then assert the user-audible outcome.
+test.describe('iOS-like playback denial — sound carry', () => {
+
+  test('when the error sound cannot start, the loading element carries it', async ({ page }) => {
+    test.setTimeout(60_000);
+    const c = ui(page);
+
+    let connectionDown = false;
+    await page.route(STREAM_URL_RE, async (route) => {
+      if (connectionDown) {
+        await route.abort('internetdisconnected');
+        return;
+      }
+      await route.fulfill({ status: 200, contentType: 'audio/mpeg', path: 'src/public/sounds/test-tone.mp3' });
+    });
+
+    await page.goto('/');
+    await waitForSoundBlobs(page);
+    await c.playButton.click();
+    await expect(c.pauseButton).toBeVisible({ timeout: 8000 });
+
+    // From here on, the error element behaves like backgrounded iOS: every
+    // fresh start is denied.
+    await page.evaluate(() => {
+      const el = document.getElementById('errorNoise');
+      el.play = () => Promise.reject(new DOMException('denied', 'NotAllowedError'));
+    });
+
+    connectionDown = true;
+    await page.context().setOffline(true);
+
+    // The loading sound starts (retrying); remember its own source.
+    await expectSoundPlaying(page, 'loadingNoise');
+    const loadingOwnSrc = await page.evaluate(() => document.getElementById('loadingNoise').src);
+
+    await expect(c.errorMsg).toBeVisible({ timeout: 10000 });
+
+    // The user must NOT end up in silence: the loading element keeps playing
+    // and, once the supervisor notices the denied start, carries the error
+    // tone (its source switches away from its own sound).
+    await page.waitForFunction((ownSrc) => {
+      const carrier = document.getElementById('loadingNoise');
+      return !carrier.paused && Boolean(carrier.src) && carrier.src !== ownSrc;
+    }, loadingOwnSrc, { timeout: 10000 });
+
+    // …while the denied element itself never started.
+    const errorPaused = await page.evaluate(() => document.getElementById('errorNoise').paused);
+    expect(errorPaused).toBe(true);
+
+    // The network returns: the radio recovers and every feedback sound stops,
+    // including the carrying element.
+    connectionDown = false;
+    await page.context().setOffline(false);
+    await expect(c.pauseButton).toBeVisible({ timeout: 45000 });
+    await page.waitForFunction(() =>
+      document.getElementById('loadingNoise').paused &&
+      document.getElementById('errorNoise').paused,
+      { timeout: 5000 });
+  });
+});

--- a/e2e/radio.spec.js
+++ b/e2e/radio.spec.js
@@ -680,8 +680,10 @@ test.describe('Offline — cached resources', () => {
     await expect(c.errorMsg).toBeVisible({ timeout: 3000 });
     await expectSoundPlaying(page, 'errorNoise');
 
-    const loadingPaused = await page.evaluate(() => document.getElementById('loadingNoise').paused);
-    expect(loadingPaused).toBe(true);
+    // The loading sound hands off gracefully: it may keep playing for the few
+    // ms until the error sound actually produces audio (iOS session handoff),
+    // but once the error sound is on, the loading one must fall silent.
+    await page.waitForFunction(() => document.getElementById('loadingNoise').paused, { timeout: 3000 });
   });
 
   test('error sound plays while offline, with no sound network request', async ({ page }) => {

--- a/plan.md
+++ b/plan.md
@@ -134,6 +134,19 @@ dat pauza. Cauze gasite si fixate (branch `fix/always-audible-offline`):
    (invariantul: orice sunet > liniste) iar supervizorul reincearca.
    Testul e2e 'offline station change...' actualizat la noua semantica
    (asteapta finalizarea handoff-ului, nu opririle instantanee).
+7. Carry (confirmat pe iPhone real): iOS in background REFUZA orice
+   pornire proaspata de element audio, dar PERMITE unui element care
+   deja canta sa-si schimbe src si sa continue (pattern-ul playlist).
+   Daca sunetul de eroare nu porneste pana la tick-ul supervizorului,
+   elementul de loading (audibil) ii "cara" tonul — carrySound(). Protocol
+   documentat in script.ts; testat e2e prin simularea refuzului iOS
+   (describe 'iOS-like playback denial', exceptie white-box justificata).
+8. Reactie instant la evenimentul window 'offline' (in loc de ~6s de
+   watchdog) — watchdog-ul ramane pentru wifi-fara-internet.
+9. Widget-ul Now Playing pe macOS ramane gol in starea de eroare offline —
+   limitare cunoscuta, acceptata (3 tentative de fix revertate: re-assert
+   amanat, hook-uri pe evenimentele playerului, artwork scos offline).
+   Edge case rar pe laptop; de reluat doar daca devine suparator.
 
 Teste: 63 unit (incl. 'error sound stays audible indefinitely' si testul de
 ordine play-inainte-de-stop), 37 e2e — cele 35 vechi neatinse si verzi.

--- a/plan.md
+++ b/plan.md
@@ -127,6 +127,13 @@ dat pauza. Cauze gasite si fixate (branch `fix/always-audible-offline`):
    suprapunere) — golul de tacere dintre stop si play era exact locul unde
    iOS refuza play() in background/lock screen. (banuit vinovat pentru
    "eroarea nu se aude pe lock screen desi loading da")
+6. Handoff real intre sunete (branch `fix/sound-handoff`): play() doar
+   INITIAZA pornirea (async) — punctul 5 nu garanta suprapunerea. Acum
+   stop()-ul sunetului vechi se amana pana cand cel nou emite efectiv
+   'playing'; daca iOS refuza pornirea, cel vechi continua sa cante
+   (invariantul: orice sunet > liniste) iar supervizorul reincearca.
+   Testul e2e 'offline station change...' actualizat la noua semantica
+   (asteapta finalizarea handoff-ului, nu opririle instantanee).
 
 Teste: 63 unit (incl. 'error sound stays audible indefinitely' si testul de
 ordine play-inainte-de-stop), 37 e2e — cele 35 vechi neatinse si verzi.

--- a/src/js/radioCore.test.ts
+++ b/src/js/radioCore.test.ts
@@ -1316,3 +1316,50 @@ describe('sound supervisor', () => {
     expect(supervisorCount()).toBe(0);
   });
 });
+
+// =============================================
+// FAST OFFLINE REACTION — the 'offline' event beats the watchdog
+// =============================================
+
+describe('onNetworkOffline', () => {
+  it('reacts instantly while playing: retrying with the loading sound, no watchdog wait', async () => {
+    let online = true;
+    const { deps, calls } = makeDeps({ isOnline: () => online });
+    const core = createRadioCore(deps);
+
+    core.playRadio(0);
+    await flushPromises();
+    expect(core.getState()).toBe('playing');
+
+    online = false;
+    core.onNetworkOffline(); // window 'offline' event
+
+    expect(core.getState()).toBe('retrying');
+    expect(calls.loadingSound.at(-1)).toBe('play');
+
+    fireTimer(deps, 3000); // the retry runs while still offline → error
+    expect(core.getState()).toBe('error');
+    expect(calls.errorSound.at(-1)).toBe('play');
+  });
+
+  it('does nothing outside playing (paused stays paused, idle stays idle)', async () => {
+    let online = true;
+    const { deps } = makeDeps({ isOnline: () => online });
+    const core = createRadioCore(deps);
+
+    online = false;
+    core.onNetworkOffline();
+    expect(core.getState()).toBe('idle');
+
+    online = true;
+    core.playRadio(0);
+    await flushPromises();
+    core.pauseRadio();
+    core.onPlayerPause();
+    expect(core.getState()).toBe('paused');
+
+    online = false;
+    core.onNetworkOffline();
+    expect(core.getState()).toBe('paused');
+  });
+});

--- a/src/js/radioCore.ts
+++ b/src/js/radioCore.ts
@@ -347,6 +347,16 @@ export function createRadioCore(deps: RadioDeps) {
     }
   }
 
+  // Called from the window 'offline' event: the browser KNOWS the network is
+  // gone, so don't wait ~6s for the watchdog to notice the frozen stream —
+  // start the audible retry/error pipeline immediately. The watchdog still
+  // covers wifi-without-internet, where no 'offline' event ever fires.
+  function onNetworkOffline() {
+    if (getState() !== 'playing') return;
+    lastPauseTime = null;
+    handlePlayError(currentPlayId, getSelectedIndex(), new Error('Network offline'));
+  }
+
   // --- Playback watchdog ---
   // Stream failures often don't fire any 'error'/'stalled' event — the audio
   // just goes silent while currentTime stops advancing (classic with HLS or
@@ -496,6 +506,7 @@ export function createRadioCore(deps: RadioDeps) {
     onPlayerPlay,
     onPlayerPause,
     onPlayerError,
+    onNetworkOffline,
     retryFromError,
     onPlayButtonClick,
     _getPlayId: () => currentPlayId,

--- a/src/js/script.ts
+++ b/src/js/script.ts
@@ -372,7 +372,7 @@ let lastMediaMetadataInit: MediaMetadataInit | null = null;
 let metadataReassertTimer: number | null = null;
 
 function reassertMediaMetadata() {
-  if (!lastMediaMetadataInit) return;
+  if (!('mediaSession' in navigator) || !lastMediaMetadataInit) return;
   // Deferred (and deduped): WebKit refreshes its Now Playing info right after
   // media element events — metadata assigned synchronously inside a
   // 'play'/'playing'/'pause' handler gets clobbered by that refresh.
@@ -500,7 +500,10 @@ const updateMediaSession = (newState: RadioState) => {
     lastMediaMetadataInit = {
       title: isLoading ? `${LABELS.loading}${title}` : hasError ? `${LABELS.error} la încărcarea ${title}` : isIdle ? idleText : title,
       artist: `${LABELS.appName}${isIdle && !hasRestoredStation ? '' : ` | ${title}`}`,
-      artwork: [{ src: cloudinaryImageUrl(displayText, isLive) }]
+      // The OS fetches the artwork itself (bypassing our SW cache) — offline,
+      // a failing artwork fetch can take the whole Now Playing entry with it.
+      // Better a title without an image than neither.
+      artwork: navigator.onLine ? [{ src: cloudinaryImageUrl(displayText, isLive) }] : []
     };
     navigator.mediaSession.metadata = new MediaMetadata(lastMediaMetadataInit);
 
@@ -614,7 +617,14 @@ player.addEventListener('pause', () => {
     }
   }
   core.onPlayerPause();
+  // The main element pausing (or dying entirely on stream failure) triggers
+  // WebKit's own Now Playing refresh — put our metadata back after it.
+  reassertMediaMetadata();
 });
+
+// WebKit also refreshes Now Playing when the main element's source is
+// cleared (stopRadio / offline error path sets src='').
+player.addEventListener('emptied', () => reassertMediaMetadata());
 
 // Stream failure during playback (lost WiFi, server died, etc.)
 // Silent failures (no 'error' event, audio just stops — common on HLS and

--- a/src/js/script.ts
+++ b/src/js/script.ts
@@ -135,13 +135,40 @@ async function getSoundResponse(src: string): Promise<Response> {
   return response;
 }
 
-function audioInstance(htmlElement: HTMLAudioElement) {
+interface SfxInstance {
+  play(): void;
+  stop(): void;
+  ensure(): void;
+  warmUp(): void;
+  preloadBlob(): Promise<string | null>;
+  isStartPending(): boolean;
+  onStartSettled(callback: () => void): void;
+  setPartner(partner: SfxInstance): void;
+}
+
+function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
   let initialSrc = htmlElement.querySelector('source')!.src;
   let isPlaying = false;
   let blobUrl: string | null = null;
   let playGeneration = 0;
   let preloadPromise: Promise<string | null> | null = null;
   htmlElement.dataset.blobReady = 'false';
+
+  // --- Graceful handoff state ---
+  // iOS kills the app's audio session in any gap of silence and then denies
+  // the next play(). When this sound replaces its partner (loading <-> error),
+  // the partner keeps playing until THIS element actually produces audio
+  // ('playing' event) — only then does the partner's deferred stop run.
+  let partner: SfxInstance | null = null;
+  let startPending = false;
+  let stopDeferGeneration = 0;
+  const startSettlers: Array<() => void> = [];
+
+  const settleStart = () => {
+    startPending = false;
+    while (startSettlers.length) startSettlers.shift()!();
+  };
+  htmlElement.addEventListener('playing', settleStart);
 
   const preloadBlob = () => {
     if (blobUrl) return Promise.resolve(blobUrl);
@@ -179,7 +206,11 @@ function audioInstance(htmlElement: HTMLAudioElement) {
   };
 
   const play = () => {
+    // Any play intent cancels a deferred stop queued for this instance
+    // (e.g. error → loading → error flapping while the partner never started).
+    stopDeferGeneration++;
     if (!isPlaying) {
+      startPending = true;
       const gen = ++playGeneration;
       isPlaying = true;
       if (blobUrl) {
@@ -190,13 +221,32 @@ function audioInstance(htmlElement: HTMLAudioElement) {
     }
   };
 
+  const doStop = () => {
+    playGeneration++;
+    htmlElement.pause();
+    htmlElement.src = '';
+    isPlaying = false;
+  };
+
   return {
     play,
     stop() {
-      playGeneration++;
-      htmlElement.pause();
-      htmlElement.src = '';
-      isPlaying = false;
+      // This sound will never start now — release anyone waiting on it
+      // (the partner's own deferred stop), so a user stop silences BOTH.
+      startPending = false;
+      settleStart();
+
+      // Handoff: if the replacement sound was asked to play but hasn't
+      // produced audio yet, keep this one playing until it does — a gap of
+      // silence here is where iOS would deny the replacement's play().
+      if (partner?.isStartPending()) {
+        const deferGen = ++stopDeferGeneration;
+        partner.onStartSettled(() => {
+          if (deferGen === stopDeferGeneration) doStop();
+        });
+        return;
+      }
+      doStop();
     },
     // Self-healing: called periodically by the core's sound supervisor while
     // this sound is supposed to be audible. Restarts playback if a play()
@@ -231,11 +281,21 @@ function audioInstance(htmlElement: HTMLAudioElement) {
       }).catch(() => {});
     },
     preloadBlob,
+    isStartPending: () => startPending,
+    onStartSettled(callback: () => void) {
+      startSettlers.push(callback);
+    },
+    setPartner(p: SfxInstance) {
+      partner = p;
+    },
   };
 }
 
 const loadingNoiseInstance = audioInstance(loadingNoise);
 const errorNoiseInstance = audioInstance(errorNoise);
+// Each sound hands off gracefully to the other (see audioInstance.stop()).
+loadingNoiseInstance.setPartner(errorNoiseInstance);
+errorNoiseInstance.setPartner(loadingNoiseInstance);
 
 // Eagerly preload sound blobs so loading/error feedback can start from memory.
 // fetch() doesn't need a user gesture — only playback does.

--- a/src/js/script.ts
+++ b/src/js/script.ts
@@ -135,20 +135,46 @@ async function getSoundResponse(src: string): Promise<Response> {
   return response;
 }
 
+// =====================================================================
+// Sound handoff protocol (rules verified on a real iPhone, 2026-07-03):
+//
+//   1. Backgrounded iOS DENIES any fresh play() start — even on a warmed-up
+//      element, even while another element of the page is playing.
+//   2. Backgrounded iOS ALLOWS an element that is already playing to swap
+//      its src and continue (the playlist pattern).
+//
+// Product invariant: once the user pressed play, something must always be
+// audible. So when one feedback sound replaces the other (loading <-> error):
+//
+//   - deferred stop  — the OLD sound keeps playing until the NEW one actually
+//     produces audio (its 'playing' event); no silent gap ever opens.
+//   - carry          — if the new sound still hasn't started by a supervisor
+//     tick (rule 1 denied it) while the old one is audible, the old ELEMENT
+//     carries the new sound: its src is swapped to the new tone (rule 2).
+//   - reclaim        — play()/stop() on a carrying element automatically
+//     restore its own sound / release the deferral.
+//
+// A user stop/pause silences both immediately: stopping a still-pending
+// sound settles it, which releases the partner's deferred stop too.
+// =====================================================================
+
 interface SfxInstance {
   play(): void;
   stop(): void;
+  /** Supervisor hook: re-assert playback if a play() was denied or the OS
+   *  paused the element; escalates to carry() on the partner (see protocol). */
   ensure(): void;
   warmUp(): void;
   preloadBlob(): Promise<string | null>;
+  /** True between play() and the element actually producing audio. */
   isStartPending(): boolean;
+  /** Runs callback once this sound starts OR is stopped — whichever first. */
   onStartSettled(callback: () => void): void;
   setPartner(partner: SfxInstance): void;
   isAudiblyPlaying(): boolean;
-  /** Last-resort iOS takeover: swap this (already playing) element's source
-   *  to the partner's sound — a continuation, which backgrounded iOS allows,
-   *  unlike the fresh start it just denied. */
-  hijackWith(src: string): void;
+  /** Carry the partner's sound on this (already playing) element: swap src
+   *  and continue — the one playback start backgrounded iOS allows. */
+  carrySound(src: string): void;
 }
 
 function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
@@ -159,16 +185,12 @@ function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
   let preloadPromise: Promise<string | null> | null = null;
   htmlElement.dataset.blobReady = 'false';
 
-  // --- Graceful handoff state ---
-  // iOS kills the app's audio session in any gap of silence and then denies
-  // the next play(). When this sound replaces its partner (loading <-> error),
-  // the partner keeps playing until THIS element actually produces audio
-  // ('playing' event) — only then does the partner's deferred stop run.
+  // --- Handoff state (see protocol above) ---
   let partner: SfxInstance | null = null;
   let startPending = false;
-  let stopDeferGeneration = 0;
-  let borrowedSrc: string | null = null; // set while this element carries the partner's sound
-  let hijackAttempted = false; // one takeover attempt per play cycle
+  let deferredStopGeneration = 0; // invalidates a queued deferred stop
+  let carriedSrc: string | null = null; // set while carrying the partner's sound
+  let carryAttempted = false; // ask the partner to carry at most once per play cycle
   const startSettlers: Array<() => void> = [];
 
   const settleStart = () => {
@@ -213,13 +235,13 @@ function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
   };
 
   const play = () => {
-    // Any play intent cancels a deferred stop queued for this instance
-    // (e.g. error → loading → error flapping while the partner never started).
-    stopDeferGeneration++;
-    hijackAttempted = false;
-    if (borrowedSrc) {
-      // The element is carrying the partner's sound — reclaim it with our own.
-      borrowedSrc = null;
+    // Fresh play intent: cancel a queued deferred stop for this instance
+    // (error → loading → error flapping while the partner never started)
+    // and reclaim the element if it was carrying the partner's sound.
+    deferredStopGeneration++;
+    carryAttempted = false;
+    if (carriedSrc) {
+      carriedSrc = null;
       isPlaying = false;
     }
     if (!isPlaying) {
@@ -239,33 +261,30 @@ function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
     htmlElement.pause();
     htmlElement.src = '';
     isPlaying = false;
-    borrowedSrc = null;
-    hijackAttempted = false;
+    carriedSrc = null;
+    carryAttempted = false;
   };
 
   return {
     play,
     stop() {
-      // This sound will never start now — release anyone waiting on it
-      // (the partner's own deferred stop), so a user stop silences BOTH.
+      // This sound will never start now — settle it, which also releases a
+      // partner waiting on us (so a user stop silences BOTH immediately).
       startPending = false;
       settleStart();
 
-      // Handoff: if the replacement sound was asked to play but hasn't
-      // produced audio yet, keep this one playing until it does — a gap of
-      // silence here is where iOS would deny the replacement's play().
+      // Deferred stop: while the replacement sound hasn't produced audio yet,
+      // keep this one playing (see protocol rule 1 — the silent gap is where
+      // iOS denies the replacement's start).
       if (partner?.isStartPending()) {
-        const deferGen = ++stopDeferGeneration;
+        const gen = ++deferredStopGeneration;
         partner.onStartSettled(() => {
-          if (deferGen === stopDeferGeneration) doStop();
+          if (gen === deferredStopGeneration) doStop();
         });
         return;
       }
       doStop();
     },
-    // Self-healing: called periodically by the core's sound supervisor while
-    // this sound is supposed to be audible. Restarts playback if a play()
-    // was rejected (background/autoplay policy) or the OS paused the element.
     ensure() {
       if (!isPlaying) {
         play();
@@ -277,13 +296,11 @@ function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
         });
       }
 
-      // iOS last resort: we still haven't produced audio (backgrounded iOS
-      // denies FRESH playback starts), but the partner element is audibly
-      // playing — and a playing element may swap sources and continue
-      // (playlist-style). Borrow it so the right sound is heard.
-      if (startPending && htmlElement.paused && !hijackAttempted && partner?.isAudiblyPlaying()) {
-        hijackAttempted = true;
-        partner.hijackWith(blobUrl || initialSrc);
+      // Escalation: our start keeps being denied but the partner element is
+      // audible — have IT carry our sound (protocol rule 2).
+      if (startPending && htmlElement.paused && !carryAttempted && partner?.isAudiblyPlaying()) {
+        carryAttempted = true;
+        partner.carrySound(blobUrl || initialSrc);
       }
     },
     warmUp() {
@@ -311,16 +328,16 @@ function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
       partner = p;
     },
     isAudiblyPlaying: () => isPlaying && !htmlElement.paused,
-    hijackWith(src: string) {
-      if (!isPlaying || htmlElement.paused) return; // nothing audible to borrow
-      if (borrowedSrc === src) return;              // already carrying it
-      borrowedSrc = src;
+    carrySound(src: string) {
+      if (!isPlaying || htmlElement.paused) return; // nothing audible to lend
+      if (carriedSrc === src) return;               // already carrying it
+      carriedSrc = src;
       htmlElement.src = src;
       htmlElement.currentTime = 0;
       htmlElement.play().catch(() => {
-        // The continuation was denied too — restore our own sound rather
-        // than end up fully silent.
-        borrowedSrc = null;
+        // Even the continuation was denied — restore our own sound rather
+        // than trade something audible for silence.
+        carriedSrc = null;
         htmlElement.src = blobUrl || initialSrc;
         htmlElement.currentTime = 0;
         htmlElement.play().catch(() => {});

--- a/src/js/script.ts
+++ b/src/js/script.ts
@@ -144,6 +144,11 @@ interface SfxInstance {
   isStartPending(): boolean;
   onStartSettled(callback: () => void): void;
   setPartner(partner: SfxInstance): void;
+  isAudiblyPlaying(): boolean;
+  /** Last-resort iOS takeover: swap this (already playing) element's source
+   *  to the partner's sound — a continuation, which backgrounded iOS allows,
+   *  unlike the fresh start it just denied. */
+  hijackWith(src: string): void;
 }
 
 function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
@@ -162,6 +167,8 @@ function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
   let partner: SfxInstance | null = null;
   let startPending = false;
   let stopDeferGeneration = 0;
+  let borrowedSrc: string | null = null; // set while this element carries the partner's sound
+  let hijackAttempted = false; // one takeover attempt per play cycle
   const startSettlers: Array<() => void> = [];
 
   const settleStart = () => {
@@ -209,6 +216,12 @@ function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
     // Any play intent cancels a deferred stop queued for this instance
     // (e.g. error → loading → error flapping while the partner never started).
     stopDeferGeneration++;
+    hijackAttempted = false;
+    if (borrowedSrc) {
+      // The element is carrying the partner's sound — reclaim it with our own.
+      borrowedSrc = null;
+      isPlaying = false;
+    }
     if (!isPlaying) {
       startPending = true;
       const gen = ++playGeneration;
@@ -226,6 +239,8 @@ function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
     htmlElement.pause();
     htmlElement.src = '';
     isPlaying = false;
+    borrowedSrc = null;
+    hijackAttempted = false;
   };
 
   return {
@@ -254,14 +269,21 @@ function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
     ensure() {
       if (!isPlaying) {
         play();
-        return;
-      }
-      if (htmlElement.paused) {
+      } else if (htmlElement.paused) {
         const gen = playGeneration;
         htmlElement.play().catch((error) => {
           if (gen !== playGeneration) return;
           if (error.name !== 'AbortError') isPlaying = false; // retried next tick
         });
+      }
+
+      // iOS last resort: we still haven't produced audio (backgrounded iOS
+      // denies FRESH playback starts), but the partner element is audibly
+      // playing — and a playing element may swap sources and continue
+      // (playlist-style). Borrow it so the right sound is heard.
+      if (startPending && htmlElement.paused && !hijackAttempted && partner?.isAudiblyPlaying()) {
+        hijackAttempted = true;
+        partner.hijackWith(blobUrl || initialSrc);
       }
     },
     warmUp() {
@@ -287,6 +309,22 @@ function audioInstance(htmlElement: HTMLAudioElement): SfxInstance {
     },
     setPartner(p: SfxInstance) {
       partner = p;
+    },
+    isAudiblyPlaying: () => isPlaying && !htmlElement.paused,
+    hijackWith(src: string) {
+      if (!isPlaying || htmlElement.paused) return; // nothing audible to borrow
+      if (borrowedSrc === src) return;              // already carrying it
+      borrowedSrc = src;
+      htmlElement.src = src;
+      htmlElement.currentTime = 0;
+      htmlElement.play().catch(() => {
+        // The continuation was denied too — restore our own sound rather
+        // than end up fully silent.
+        borrowedSrc = null;
+        htmlElement.src = blobUrl || initialSrc;
+        htmlElement.currentTime = 0;
+        htmlElement.play().catch(() => {});
+      });
     },
   };
 }

--- a/src/js/script.ts
+++ b/src/js/script.ts
@@ -369,11 +369,20 @@ function registerMediaSessionHandlers() {
 // changes (sound handoffs/hijacks), because macOS ties the Now Playing widget
 // to the active element and drops the metadata when a different one takes over.
 let lastMediaMetadataInit: MediaMetadataInit | null = null;
+let metadataReassertTimer: number | null = null;
 
 function reassertMediaMetadata() {
-  if (lastMediaMetadataInit) {
-    navigator.mediaSession.metadata = new MediaMetadata(lastMediaMetadataInit);
-  }
+  if (!lastMediaMetadataInit) return;
+  // Deferred (and deduped): WebKit refreshes its Now Playing info right after
+  // media element events — metadata assigned synchronously inside a
+  // 'play'/'playing'/'pause' handler gets clobbered by that refresh.
+  if (metadataReassertTimer !== null) clearTimeout(metadataReassertTimer);
+  metadataReassertTimer = setTimeout(() => {
+    metadataReassertTimer = null;
+    if (lastMediaMetadataInit) {
+      navigator.mediaSession.metadata = new MediaMetadata(lastMediaMetadataInit);
+    }
+  }, 150);
 }
 
 function reRegisterMediaSessionHandlers() {

--- a/src/js/script.ts
+++ b/src/js/script.ts
@@ -365,10 +365,22 @@ function registerMediaSessionHandlers() {
 // the lock-screen shows prev/next instead of skip ±10 s.
 // Also force playbackState='playing' so macOS doesn't briefly show "Not Playing"
 // in the gap between pausing the main player and the sound effect producing audio.
+// The last metadata we set — re-asserted whenever the active <audio> element
+// changes (sound handoffs/hijacks), because macOS ties the Now Playing widget
+// to the active element and drops the metadata when a different one takes over.
+let lastMediaMetadataInit: MediaMetadataInit | null = null;
+
+function reassertMediaMetadata() {
+  if (lastMediaMetadataInit) {
+    navigator.mediaSession.metadata = new MediaMetadata(lastMediaMetadataInit);
+  }
+}
+
 function reRegisterMediaSessionHandlers() {
   if (!('mediaSession' in navigator) || !core) return;
   navigator.mediaSession.playbackState = 'playing';
   registerMediaSessionHandlers();
+  reassertMediaMetadata();
   // iOS picks up the sound effect's duration as "now playing" — clear it.
   try { navigator.mediaSession.setPositionState({}); } catch (_) {}
 }
@@ -401,6 +413,7 @@ function reassertPlaybackState() {
   const s = core.getState();
   if (s === 'playing' || s === 'loading' || s === 'retrying' || s === 'error' || s === 'recovering') {
     navigator.mediaSession.playbackState = 'playing';
+    reassertMediaMetadata();
     try { navigator.mediaSession.setPositionState({}); } catch (_) {}
   }
 }
@@ -475,11 +488,12 @@ const updateMediaSession = (newState: RadioState) => {
   const displayText = isIdle ? idleText : isLoading ? LABELS.loading : hasError ? LABELS.error : title;
 
   if ('mediaSession' in navigator) {
-    navigator.mediaSession.metadata = new MediaMetadata({
+    lastMediaMetadataInit = {
       title: isLoading ? `${LABELS.loading}${title}` : hasError ? `${LABELS.error} la încărcarea ${title}` : isIdle ? idleText : title,
       artist: `${LABELS.appName}${isIdle && !hasRestoredStation ? '' : ` | ${title}`}`,
       artwork: [{ src: cloudinaryImageUrl(displayText, isLive) }]
-    });
+    };
+    navigator.mediaSession.metadata = new MediaMetadata(lastMediaMetadataInit);
 
     // Re-register ALL action handlers on every state transition.
     // iOS resets them when a different <audio> element (loading/error sound)

--- a/src/js/script.ts
+++ b/src/js/script.ts
@@ -635,6 +635,10 @@ player.addEventListener('error', () => core.onPlayerError());
 // Auto-recovery when network comes back
 window.addEventListener('online', () => core.retryFromError());
 
+// React instantly when the browser reports the network is gone — no need to
+// wait for the playback watchdog to notice the frozen stream.
+window.addEventListener('offline', () => core.onNetworkOffline());
+
 // Prev / Next
 prevButton.addEventListener('click', () => {
   preloadAudioBlobs();

--- a/src/js/script.ts
+++ b/src/js/script.ts
@@ -365,31 +365,10 @@ function registerMediaSessionHandlers() {
 // the lock-screen shows prev/next instead of skip ±10 s.
 // Also force playbackState='playing' so macOS doesn't briefly show "Not Playing"
 // in the gap between pausing the main player and the sound effect producing audio.
-// The last metadata we set — re-asserted whenever the active <audio> element
-// changes (sound handoffs/hijacks), because macOS ties the Now Playing widget
-// to the active element and drops the metadata when a different one takes over.
-let lastMediaMetadataInit: MediaMetadataInit | null = null;
-let metadataReassertTimer: number | null = null;
-
-function reassertMediaMetadata() {
-  if (!('mediaSession' in navigator) || !lastMediaMetadataInit) return;
-  // Deferred (and deduped): WebKit refreshes its Now Playing info right after
-  // media element events — metadata assigned synchronously inside a
-  // 'play'/'playing'/'pause' handler gets clobbered by that refresh.
-  if (metadataReassertTimer !== null) clearTimeout(metadataReassertTimer);
-  metadataReassertTimer = setTimeout(() => {
-    metadataReassertTimer = null;
-    if (lastMediaMetadataInit) {
-      navigator.mediaSession.metadata = new MediaMetadata(lastMediaMetadataInit);
-    }
-  }, 150);
-}
-
 function reRegisterMediaSessionHandlers() {
   if (!('mediaSession' in navigator) || !core) return;
   navigator.mediaSession.playbackState = 'playing';
   registerMediaSessionHandlers();
-  reassertMediaMetadata();
   // iOS picks up the sound effect's duration as "now playing" — clear it.
   try { navigator.mediaSession.setPositionState({}); } catch (_) {}
 }
@@ -422,7 +401,6 @@ function reassertPlaybackState() {
   const s = core.getState();
   if (s === 'playing' || s === 'loading' || s === 'retrying' || s === 'error' || s === 'recovering') {
     navigator.mediaSession.playbackState = 'playing';
-    reassertMediaMetadata();
     try { navigator.mediaSession.setPositionState({}); } catch (_) {}
   }
 }
@@ -497,15 +475,11 @@ const updateMediaSession = (newState: RadioState) => {
   const displayText = isIdle ? idleText : isLoading ? LABELS.loading : hasError ? LABELS.error : title;
 
   if ('mediaSession' in navigator) {
-    lastMediaMetadataInit = {
+    navigator.mediaSession.metadata = new MediaMetadata({
       title: isLoading ? `${LABELS.loading}${title}` : hasError ? `${LABELS.error} la încărcarea ${title}` : isIdle ? idleText : title,
       artist: `${LABELS.appName}${isIdle && !hasRestoredStation ? '' : ` | ${title}`}`,
-      // The OS fetches the artwork itself (bypassing our SW cache) — offline,
-      // a failing artwork fetch can take the whole Now Playing entry with it.
-      // Better a title without an image than neither.
-      artwork: navigator.onLine ? [{ src: cloudinaryImageUrl(displayText, isLive) }] : []
-    };
-    navigator.mediaSession.metadata = new MediaMetadata(lastMediaMetadataInit);
+      artwork: [{ src: cloudinaryImageUrl(displayText, isLive) }]
+    });
 
     // Re-register ALL action handlers on every state transition.
     // iOS resets them when a different <audio> element (loading/error sound)
@@ -617,14 +591,7 @@ player.addEventListener('pause', () => {
     }
   }
   core.onPlayerPause();
-  // The main element pausing (or dying entirely on stream failure) triggers
-  // WebKit's own Now Playing refresh — put our metadata back after it.
-  reassertMediaMetadata();
 });
-
-// WebKit also refreshes Now Playing when the main element's source is
-// cleared (stopRadio / offline error path sets src='').
-player.addEventListener('emptied', () => reassertMediaMetadata());
 
 // Stream failure during playback (lost WiFi, server died, etc.)
 // Silent failures (no 'error' event, audio just stops — common on HLS and


### PR DESCRIPTION
Fix-ul pentru "din prima nu aud eroarea pe lock screen, dar dacă frec butoanele merge" (testat de Adrian pe preview).

## Problema

`play()` pe un element audio doar **inițiază** pornirea (decodare/buffer, async). Reordonarea play-înainte-de-stop din PR-ul anterior nu garanta suprapunerea: sunetul vechi era oprit imediat după *inițierea* celui nou, deci rămânea un gol real de liniște. Pe iPhone blocat, în golul ăla moare sesiunea audio a aplicației și iOS refuză `play()`-ul în curs — de-aia loading-ul (pornit lângă gestul userului) se auzea, iar eroarea (pornită la ~9s de ultimul gest) nu.

## Fix

`audioInstance` urmărește acum starea "pornire în curs" (până la evenimentul `playing`), iar `stop()`-ul sunetului vechi se **amână până când înlocuitorul chiar produce audio**:

- loading → eroare (și invers): zero liniște — vechiul cântă până pornește noul
- dacă iOS refuză pornirea noului sunet: vechiul **continuă să cânte** (invariantul "orice sunet > liniște") și supervizorul reîncearcă la 2.5s
- stop/pauză de la user: liniște imediată pe ambele (oprirea unui sunet în curs de pornire eliberează și stop-ul amânat al partenerului)

## Teste

- ✅ typecheck, 63/63 unit, build, **37/37 e2e**
- O aserțiune e2e actualizată la noua semantică (schimbare deliberată de comportament): `offline station change plays the error sound, not the loading one` — verifica instantaneu că loading-ul e oprit; acum așteaptă finalizarea handoff-ului. Intenția testului (în final se aude doar eroarea) e neschimbată.
- **Testul decisiv e la tine**: preview pe telefon → play → net tăiat → lock screen → eroarea ar trebui să se audă din prima, fără frecat de butoane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)