### PR TITLE
R2: one source of truth for state classification

### DIFF
--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -3,7 +3,7 @@
  * through the feature modules. No business logic lives here, only wiring.
  */
 
-import { createRadioCore } from './radioCore';
+import { createRadioCore, isLoadingLike } from './radioCore';
 import {
   radioSelect, player, loadingNoise, errorNoise, loadingMsg, errorMsg,
   prevButton, playButton, pauseButton, stopButton, nextButton, logoButton,
@@ -179,8 +179,11 @@ player.addEventListener('pause', () => {
   // During loading/retrying/recovering the main player pauses while the loading
   // sound takes over.  Actively re-assert 'playing' so macOS doesn't flash
   // "Not Playing" in the gap.  Only signal 'paused' in normal playback states.
+  // NOTE: deliberately narrower than isFeedbackAudible — 'error' is not
+  // re-asserted here (pre-existing drift from the other three state lists;
+  // whether that's intent or a bug gets decided in faza R3/R5, not silently).
   if ('mediaSession' in navigator) {
-    if (s === 'loading' || s === 'retrying' || s === 'recovering') {
+    if (isLoadingLike(s) || s === 'recovering') {
       navigator.mediaSession.playbackState = 'playing';
     } else if (s === 'playing') {
       navigator.mediaSession.playbackState = 'paused';

--- a/src/js/mediaSession.ts
+++ b/src/js/mediaSession.ts
@@ -10,6 +10,7 @@
  */
 
 import type { RadioCore, RadioState } from './radioCore';
+import { isLoadingLike, isErrorLike, isFeedbackAudible, playbackStateFor } from './radioCore';
 import { LABELS } from './labels';
 import { cloudinaryImageUrl } from './cloudinary';
 import { radioSelect, posterImage, loadingMsg, loadingNoise, errorNoise } from './dom';
@@ -38,10 +39,9 @@ function registerMediaSessionHandlers() {
   navigator.mediaSession.setActionHandler('nexttrack',     () => core?.nextRadio());
   navigator.mediaSession.setActionHandler('pause', () => {
     if (!core) return;
-    const s = core.getState();
-    // During loading/error the sound effects are playing, not the stream.
-    // "Pause" should cancel everything (same as the on-screen stop button).
-    if (s === 'loading' || s === 'retrying' || s === 'error' || s === 'recovering') {
+    // While a feedback sound is what's audible (not the stream), "pause"
+    // should cancel everything (same as the on-screen stop button).
+    if (isFeedbackAudible(core.getState())) {
       core.stopRadio();
     } else {
       core.pauseRadio();
@@ -90,8 +90,7 @@ errorNoise.addEventListener('timeupdate', clearPositionState);
 // it picks up audio from the main player.
 function reassertPlaybackState() {
   if (!('mediaSession' in navigator) || !core) return;
-  const s = core.getState();
-  if (s === 'playing' || s === 'loading' || s === 'retrying' || s === 'error' || s === 'recovering') {
+  if (playbackStateFor(core.getState()) === 'playing') {
     navigator.mediaSession.playbackState = 'playing';
     clearPositionState();
   }
@@ -102,8 +101,8 @@ errorNoise.addEventListener('pause', reassertPlaybackState);
 export const updateMediaSession = (newState: RadioState) => {
   const title = radioSelect.options[radioSelect.selectedIndex].text;
   const isIdle = newState === 'idle';
-  const isLoading = newState === 'loading' || newState === 'retrying';
-  const hasError = newState === 'error' || newState === 'recovering';
+  const isLoading = isLoadingLike(newState);
+  const hasError = isErrorLike(newState);
   const isLive = newState === 'playing';
 
   const idleText = hasRestoredStation ? title : LABELS.appName;
@@ -124,11 +123,11 @@ export const updateMediaSession = (newState: RadioState) => {
     }
 
     // Keep session alive during loading/error (sounds are playing via <audio>)
-    navigator.mediaSession.playbackState = (isLive || isLoading || hasError) ? 'playing' : newState === 'paused' ? 'paused' : 'none';
+    navigator.mediaSession.playbackState = playbackStateFor(newState);
 
     // Clear position state for active/paused states — tells the OS there's no
     // seekable timeline, so it won't show a finite progress bar.
-    if (isLive || isLoading || hasError || newState === 'paused') {
+    if (playbackStateFor(newState) !== 'none') {
       clearPositionState();
     }
   }

--- a/src/js/radioCore.test.ts
+++ b/src/js/radioCore.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SimulatedClock } from 'xstate';
 import {
   createRadioCore,
+  isLoadingLike,
+  isErrorLike,
+  isFeedbackAudible,
+  playbackStateFor,
   RECOVERY_DELAY_MS,
   RECOVERY_DELAY_MAX_MS,
   WATCHDOG_INTERVAL_MS,
@@ -9,6 +13,7 @@ import {
   SOUND_SUPERVISOR_INTERVAL_MS,
   USER_PAUSE_INTENT_MS,
   type RadioDeps,
+  type RadioState,
 } from './radioCore';
 
 // --- Helpers ---
@@ -1297,5 +1302,31 @@ describe('sound supervisor', () => {
 
     core.stopRadio();
     expect(supervisorCount()).toBe(0);
+  });
+});
+
+// =============================================
+// STATE CLASSIFICATION (single source of truth for the DOM layer)
+// =============================================
+
+describe('state classification predicates', () => {
+  it('classifies every state exactly as STATE_FX presents it', () => {
+    const table: Record<RadioState, {
+      loadingLike: boolean; errorLike: boolean; playback: 'playing' | 'paused' | 'none';
+    }> = {
+      idle:       { loadingLike: false, errorLike: false, playback: 'none' },
+      loading:    { loadingLike: true,  errorLike: false, playback: 'playing' },
+      playing:    { loadingLike: false, errorLike: false, playback: 'playing' },
+      paused:     { loadingLike: false, errorLike: false, playback: 'paused' },
+      retrying:   { loadingLike: true,  errorLike: false, playback: 'playing' },
+      error:      { loadingLike: false, errorLike: true,  playback: 'playing' },
+      recovering: { loadingLike: false, errorLike: true,  playback: 'playing' },
+    };
+    for (const [state, expected] of Object.entries(table) as Array<[RadioState, typeof table[RadioState]]>) {
+      expect(isLoadingLike(state), `isLoadingLike(${state})`).toBe(expected.loadingLike);
+      expect(isErrorLike(state), `isErrorLike(${state})`).toBe(expected.errorLike);
+      expect(isFeedbackAudible(state), `isFeedbackAudible(${state})`).toBe(expected.loadingLike || expected.errorLike);
+      expect(playbackStateFor(state), `playbackStateFor(${state})`).toBe(expected.playback);
+    }
   });
 });

--- a/src/js/radioCore.ts
+++ b/src/js/radioCore.ts
@@ -24,6 +24,12 @@ type ActorOptions = NonNullable<Parameters<typeof createActor>[1]>;
 // here so the rest of the app keeps a single import surface.
 export type { RadioState, FeedbackSound, RadioDeps } from './radioMachine';
 export {
+  isLoadingLike,
+  isErrorLike,
+  isFeedbackAudible,
+  playbackStateFor,
+} from './radioMachine';
+export {
   MAX_RETRIES,
   LOADING_TIMEOUT_MS,
   RETRY_DELAY_MS,

--- a/src/js/radioMachine.ts
+++ b/src/js/radioMachine.ts
@@ -96,6 +96,27 @@ interface StateFx {
   errorMsg: boolean;
 }
 
+// --- State classification: the single source of truth for the DOM layer ---
+// Derived from what STATE_FX presents; DOM modules must not hand-maintain
+// their own state lists (they drifted before — see plan.md, faza R2).
+
+/** States presenting as "loading": loading tone + loading message. */
+export const isLoadingLike = (s: RadioState): boolean =>
+  s === 'loading' || s === 'retrying';
+
+/** States presenting as "error": error tone and/or error visuals. */
+export const isErrorLike = (s: RadioState): boolean =>
+  s === 'error' || s === 'recovering';
+
+/** States where a feedback sound, not the stream, is what's audible. */
+export const isFeedbackAudible = (s: RadioState): boolean =>
+  isLoadingLike(s) || isErrorLike(s);
+
+/** What the OS lock screen / Now Playing should report for a state —
+ *  'playing' whenever ANYTHING is audible (stream or feedback sound). */
+export const playbackStateFor = (s: RadioState): 'playing' | 'paused' | 'none' =>
+  s === 'playing' || isFeedbackAudible(s) ? 'playing' : s === 'paused' ? 'paused' : 'none';
+
 const STATE_FX: Record<RadioState, StateFx> = {
   idle:       { button: 'play',  loading: 'stop',  error: 'stop',  loadingMsg: false, errorMsg: false },
   loading:    { button: 'stop',  loading: 'play',  error: 'stop',  loadingMsg: true,  errorMsg: false },


### PR DESCRIPTION
Second phase of the post-review refactor plan (`plan.md`, R2). **Zero behavior change** — untouched e2e suite **37/37 green**, clean typecheck, 62/62 unit (61 old + 1 new), identical build.

The "which states count as loading / error / audible" classification was hand-spelled in **four places** across `main.ts` and `mediaSession.ts`, and the review showed they had already drifted once (commit a667b7f had to edit them when the error-sound semantics changed).

## What changed

- New predicates next to `STATE_FX` in `radioMachine.ts`, re-exported through `radioCore`:
  - `isLoadingLike` (loading|retrying), `isErrorLike` (error|recovering), `isFeedbackAudible` (their union), `playbackStateFor` (what the OS lock screen should report).
- `mediaSession.ts`: the `'pause'` action handler, `reassertPlaybackState`, and `updateMediaSession` (including the `playbackState` and position-clear expressions) now all derive from the predicates.
- `main.ts`: the player `'pause'` listener keeps its **exact** current set (`isLoadingLike(s) || s === 'recovering'`, deliberately without `'error'`) — the pre-existing drift is now explicit and commented instead of hidden in a fourth hand-typed list. Whether it's intent or a bug gets decided in R3/R5.
- New unit test locks the full 7-state classification table, so adding/renaming a machine state forces a conscious decision here instead of a silent fall-through.

Adding a new `RadioState` now hits: the exhaustive `STATE_FX` record (compile error), the predicates one line away, and the classification test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)